### PR TITLE
fix(docker-compose): add DB_REQUIRE_LOGIN to false in .dockerenv

### DIFF
--- a/studio-api/.dockerenv
+++ b/studio-api/.dockerenv
@@ -9,6 +9,7 @@ WEBSERVER_SWAGGER_API_PATH=cm-api
 DB_HOST=studio-mongo
 DB_PORT=27017
 DB_NAME=conversations
+DB_REQUIRE_LOGIN=false
 
 # Request a specific version of the database (optional)
 DB_MIGRATION_TARGET=1.4.2


### PR DESCRIPTION
MongoDB is configured with authentication in docker compose but not studio-api (because of the .envdefault).