### PR TITLE
Fix maximum number of speaker

### DIFF
--- a/studio-frontend/src/components/ConversationCreateService.vue
+++ b/studio-frontend/src/components/ConversationCreateService.vue
@@ -194,7 +194,7 @@ export default {
                 ? parseInt(this.speakersNumber.value)
                 : null,
             maxNumberOfSpeaker:
-              this.diarization.value !== "disabled" ? 8 : null,
+              this.diarization.value !== "disabled" ? 100 : null,
             serviceName:
               this.diarization.value !== "disabled"
                 ? this.diarization.value


### PR DESCRIPTION
8 is too low for the maximum number of speakers (in the "auto" mode, that was experimental and is now shipped in all versions of LinTO Studio).

Let's put 100 for now.

And maybe plan for the future to handle "null" on the linto-diarization side to decide a value based on the audio length (for instance).