### PR TITLE
Separate microphone and bot rights from session permission

### DIFF
--- a/studio-api/.envdefault
+++ b/studio-api/.envdefault
@@ -23,7 +23,7 @@ DB_PASS=example
 DB_NAME=conversations
 
 # Request a specific version of the database (optional)
-DB_MIGRATION_TARGET=1.8.4
+DB_MIGRATION_TARGET=1.8.5
 
 # STT Config
 GATEWAY_SERVICES=https://<domain>
@@ -80,8 +80,8 @@ EXPORT_TEMPLATE=default
 # Export timeout in milliseconds (default: 10 minutes)
 EXPORT_TIMEOUT_MS=600000
 
-# ORGANIZATION_DEFAULT_PERMISSIONS supported value are "upload,summary,session"
-ORGANIZATION_DEFAULT_PERMISSIONS=upload,summary,session
+# ORGANIZATION_DEFAULT_PERMISSIONS supported values are "upload,summary,session,microphone,bot"
+ORGANIZATION_DEFAULT_PERMISSIONS=upload,summary,session,microphone,bot
 
 
 SUPER_ADMIN_EMAIL=

--- a/studio-api/README.md
+++ b/studio-api/README.md
@@ -92,13 +92,15 @@ By default, each newly created organization is granted the following permissions
 
 - **Upload**: Grants access to use the transcription service to upload and process media.
 - **Summary**: Enables the use of large language models (LLM) to generate summaries for uploaded media.
-- **Session**: Provides access to the Session API, allowing the organization to create live meetings.
+- **Session**: Provides access to the Session API for managing live meeting sessions and templates.
+- **Microphone**: Allows the organization to create microphone-based live sessions (quick meetings).
+- **Bot**: Allows the organization to create bot-based live sessions (visioconference).
 
 These default permissions can be set up on project startup or adjusted individually in the back office by the superuser.
 To configure default permissions at startup, set the following variable in the `.env` file:
 
 ```bash
-ORGANIZATION_DEFAULT_PERMISSIONS=upload,summary,session
+ORGANIZATION_DEFAULT_PERMISSIONS=upload,summary,session,microphone,bot
 ```
 
 > **Note**: If any default permission is removed, future organizations will not have access to that functionality unless the superuser grants it in the back office.

--- a/studio-api/components/MongoMigration/version/1.8.5/organizationSessionPermissions.js
+++ b/studio-api/components/MongoMigration/version/1.8.5/organizationSessionPermissions.js
@@ -1,0 +1,53 @@
+const debug = require("debug")(
+  `linto:components:MongoMigration:version:1.8.5:organizationSessionPermissions`,
+)
+
+const PERMISSIONS = require(
+  `${process.cwd()}/lib/dao/organization/permissions`,
+)
+
+// Bit 4 was SESSION in the legacy schema; it now means MICROPHONE. Orgs
+// holding the legacy SESSION bit are granted the new BOT and SESSION bits so
+// existing capabilities are preserved (bit 4 carries over as MICROPHONE).
+const LEGACY_SESSION_BIT = 4
+const NEW_BITS = PERMISSIONS.BOT | PERMISSIONS.SESSION
+
+module.exports = {
+  async up(db) {
+    const cursor = db.collection("organizations").find({
+      permissions: { $bitsAllSet: LEGACY_SESSION_BIT },
+    })
+
+    let updated = 0
+    while (await cursor.hasNext()) {
+      const org = await cursor.next()
+      const next = (org.permissions || 0) | NEW_BITS
+      if (next === org.permissions) continue
+      await db
+        .collection("organizations")
+        .updateOne({ _id: org._id }, { $set: { permissions: next } })
+      updated++
+    }
+    debug(
+      `Granted BOT|SESSION to ${updated} organizations holding legacy SESSION bit`,
+    )
+  },
+
+  async down(db) {
+    const mask = ~NEW_BITS
+    const cursor = db.collection("organizations").find({
+      permissions: { $bitsAnySet: NEW_BITS },
+    })
+
+    let updated = 0
+    while (await cursor.hasNext()) {
+      const org = await cursor.next()
+      const next = (org.permissions || 0) & mask
+      await db
+        .collection("organizations")
+        .updateOne({ _id: org._id }, { $set: { permissions: next } })
+      updated++
+    }
+    debug(`Cleared BOT|SESSION bits on ${updated} organizations`)
+  },
+}

--- a/studio-api/components/MongoMigration/version/1.8.5/version.js
+++ b/studio-api/components/MongoMigration/version/1.8.5/version.js
@@ -1,0 +1,20 @@
+const debug = require("debug")(
+  `linto:components:MongoMigration:version:1.8.5:version`,
+)
+
+const previous_version = "1.8.3"
+const version = "1.8.5"
+
+module.exports = {
+  async up(db) {
+    return db
+      .collection("version")
+      .updateMany({}, { $set: { version: version } })
+  },
+
+  async down(db) {
+    return db
+      .collection("version")
+      .updateMany({}, { $set: { version: previous_version } })
+  },
+}

--- a/studio-api/components/WebServer/middlewares/access/organization.js
+++ b/studio-api/components/WebServer/middlewares/access/organization.js
@@ -98,6 +98,12 @@ module.exports = {
   permissionSession: async (req, res, next) => {
     await permissionAccess(req, res, next, PERMISSIONS.SESSION)
   },
+  permissionMicrophone: async (req, res, next) => {
+    await permissionAccess(req, res, next, PERMISSIONS.MICROPHONE)
+  },
+  permissionBot: async (req, res, next) => {
+    await permissionAccess(req, res, next, PERMISSIONS.BOT)
+  },
   sessionSocketAccess: async (session, userId) => {
     return await sessionSocketAccess(session, userId, ROLES.MEMBER)
   },

--- a/studio-api/components/WebServer/routes/proxy/sessions/session.js
+++ b/studio-api/components/WebServer/routes/proxy/sessions/session.js
@@ -176,7 +176,7 @@ module.exports = (webServer) => {
         },
       },
       {
-        //quick meeting access
+        //quick meeting access (microphone)
         scrapPath: /^\/organizations\/[^/]+/,
         paths: [
           {
@@ -197,6 +197,19 @@ module.exports = (webServer) => {
             forwardParams: proxyForwardParams,
             executeBeforeResult: storeQuickMeetingFromStop.bind(webServer),
           },
+        ],
+        requireAuth: true,
+        orgaPermissionAccess: PERMISSIONS.MICROPHONE,
+        requireOrganizationQuickMeetingAccess: true,
+        rewrite: {
+          fromPath: "/quickMeeting/",
+          toPath: "/sessions/",
+        },
+      },
+      {
+        //bot access
+        scrapPath: /^\/organizations\/[^/]+/,
+        paths: [
           {
             path: "/organizations/:organizationId/bots",
             method: ["get", "post"],
@@ -209,12 +222,8 @@ module.exports = (webServer) => {
           },
         ],
         requireAuth: true,
-        orgaPermissionAccess: PERMISSIONS.SESSION,
+        orgaPermissionAccess: PERMISSIONS.BOT,
         requireOrganizationQuickMeetingAccess: true,
-        rewrite: {
-          fromPath: "/quickMeeting/",
-          toPath: "/sessions/",
-        },
       },
       {
         // Meeting Manager access

--- a/studio-api/components/WebServer/routes/router.js
+++ b/studio-api/components/WebServer/routes/router.js
@@ -38,6 +38,8 @@ const permissionMiddlewareMap = {
   [PERMISSIONS.UPLOAD]: organization_middlewares.permissionUpload,
   [PERMISSIONS.SUMMARY]: organization_middlewares.permissionSummary,
   [PERMISSIONS.SESSION]: organization_middlewares.permissionSession,
+  [PERMISSIONS.MICROPHONE]: organization_middlewares.permissionMicrophone,
+  [PERMISSIONS.BOT]: organization_middlewares.permissionBot,
 }
 
 const {

--- a/studio-api/lib/dao/organization/permissions.js
+++ b/studio-api/lib/dao/organization/permissions.js
@@ -2,19 +2,16 @@ const PERMISSIONS = Object.freeze({
   NONE: 0,
   UPLOAD: 1,
   SUMMARY: 2,
-  SESSION: 4,
+  MICROPHONE: 4,
+  BOT: 8,
+  SESSION: 16,
 
   hasRightAccess: (orgaPermission, desiredPermission) =>
     (orgaPermission & desiredPermission) == desiredPermission,
 
   isValidPermission: (value) => {
     if (value === undefined) return false
-    const validPermissions =
-      PERMISSIONS.NONE |
-      PERMISSIONS.UPLOAD |
-      PERMISSIONS.SUMMARY |
-      PERMISSIONS.SESSION
-    return (value & ~validPermissions) === 0
+    return (value & ~VALID_PERMISSIONS_MASK) === 0
   },
   getDefaultPermissions() {
     let permissionsSum = PERMISSIONS.NONE // Start with no permissions
@@ -39,5 +36,13 @@ const PERMISSIONS = Object.freeze({
     else return this.getDefaultPermissions()
   },
 })
+
+const VALID_PERMISSIONS_MASK =
+  PERMISSIONS.NONE |
+  PERMISSIONS.UPLOAD |
+  PERMISSIONS.SUMMARY |
+  PERMISSIONS.MICROPHONE |
+  PERMISSIONS.BOT |
+  PERMISSIONS.SESSION
 
 module.exports = PERMISSIONS

--- a/studio-api/package.json
+++ b/studio-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linto-studio-api",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Transcription, summarization, annotation interface for recorded audio files ",
   "main": "app.js",
   "repository": {

--- a/studio-frontend/package.json
+++ b/studio-frontend/package.json
@@ -2,7 +2,7 @@
   "name": "linto-studio-frontend",
   "author": "Romain Lopez <rlopez@linagora.com>",
   "description": "This is LinTO Studio web interface",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "license": "GNU AFFERO GPLV3",
   "repository": {
     "type": "git",

--- a/studio-frontend/src/components-mobile/BurgerMenu.vue
+++ b/studio-frontend/src/components-mobile/BurgerMenu.vue
@@ -17,7 +17,7 @@
     </div>
     <div class="burger-menu__footer-section">
       <ButtonRoller
-        v-if="isAtLeastUploader"
+        v-if="isAtLeastUploader && canStartConversationInCurrentOrganization"
         @click="startConversation"
         :label="$t('navigation.conversation.start')"
         variant="primary"

--- a/studio-frontend/src/components/UpdateOrganizationPermissions.vue
+++ b/studio-frontend/src/components/UpdateOrganizationPermissions.vue
@@ -13,6 +13,14 @@
       :field="fieldSessionPermission"
       v-model="fieldSessionPermission.value"></FormCheckbox>
 
+    <FormCheckbox
+      :field="fieldMicrophonePermission"
+      v-model="fieldMicrophonePermission.value"></FormCheckbox>
+
+    <FormCheckbox
+      :field="fieldBotPermission"
+      v-model="fieldBotPermission.value"></FormCheckbox>
+
     <div>
       <Button
         v-if="isAdmin || isSystemAdministrator"
@@ -34,10 +42,7 @@
   </section>
 </template>
 <script>
-import {
-  organizationPermissionsMixin,
-  PERMISSIONS,
-} from "@/mixins/organizationPermissions"
+import { organizationPermissionsMixin } from "@/mixins/organizationPermissions"
 import { orgaRoleMixin } from "@/mixins/orgaRole.js"
 import { platformRoleMixin } from "@/mixins/platformRole.js"
 
@@ -79,6 +84,22 @@ export default {
           "organisation.organization_permissions.session_permission",
         ),
       },
+      fieldMicrophonePermission: {
+        ...EMPTY_FIELD,
+        value: this.hasMicrophonePermission(
+          this.currentOrganization.permissions,
+        ),
+        label: this.$t(
+          "organisation.organization_permissions.microphone_permission",
+        ),
+      },
+      fieldBotPermission: {
+        ...EMPTY_FIELD,
+        value: this.hasBotPermission(this.currentOrganization.permissions),
+        label: this.$t(
+          "organisation.organization_permissions.bot_permission",
+        ),
+      },
       organizationId: this.currentOrganization._id,
     }
   },
@@ -91,6 +112,8 @@ export default {
           upload: this.fieldUploadPermission.value,
           summary: this.fieldSummaryPermission.value,
           session: this.fieldSessionPermission.value,
+          microphone: this.fieldMicrophonePermission.value,
+          bot: this.fieldBotPermission.value,
         }),
       }
 

--- a/studio-frontend/src/components/UpdateOrganizationPermissions.vue
+++ b/studio-frontend/src/components/UpdateOrganizationPermissions.vue
@@ -10,16 +10,16 @@
       v-model="fieldSummaryPermission.value"></FormCheckbox>
 
     <FormCheckbox
-      :field="fieldSessionPermission"
-      v-model="fieldSessionPermission.value"></FormCheckbox>
-
-    <FormCheckbox
       :field="fieldMicrophonePermission"
       v-model="fieldMicrophonePermission.value"></FormCheckbox>
 
     <FormCheckbox
       :field="fieldBotPermission"
       v-model="fieldBotPermission.value"></FormCheckbox>
+
+    <FormCheckbox
+      :field="fieldSessionPermission"
+      v-model="fieldSessionPermission.value"></FormCheckbox>
 
     <div>
       <Button
@@ -77,13 +77,6 @@ export default {
           "organisation.organization_permissions.summary_permission",
         ),
       },
-      fieldSessionPermission: {
-        ...EMPTY_FIELD,
-        value: this.hasSessionPermission(this.currentOrganization.permissions),
-        label: this.$t(
-          "organisation.organization_permissions.session_permission",
-        ),
-      },
       fieldMicrophonePermission: {
         ...EMPTY_FIELD,
         value: this.hasMicrophonePermission(
@@ -100,6 +93,13 @@ export default {
           "organisation.organization_permissions.bot_permission",
         ),
       },
+      fieldSessionPermission: {
+        ...EMPTY_FIELD,
+        value: this.hasSessionPermission(this.currentOrganization.permissions),
+        label: this.$t(
+          "organisation.organization_permissions.session_permission",
+        ),
+      },
       organizationId: this.currentOrganization._id,
     }
   },
@@ -111,9 +111,9 @@ export default {
         permissions: this.computePermissionsNumber({
           upload: this.fieldUploadPermission.value,
           summary: this.fieldSummaryPermission.value,
-          session: this.fieldSessionPermission.value,
           microphone: this.fieldMicrophonePermission.value,
           bot: this.fieldBotPermission.value,
+          session: this.fieldSessionPermission.value,
         }),
       }
 

--- a/studio-frontend/src/const/organizationPermissions.js
+++ b/studio-frontend/src/const/organizationPermissions.js
@@ -1,0 +1,8 @@
+export const ORGANIZATION_PERMISSIONS = Object.freeze({
+  UNDEFINED: 0,
+  UPLOAD: 1,
+  SUMMARY: 2,
+  MICROPHONE: 4,
+  BOT: 8,
+  SESSION: 16,
+})

--- a/studio-frontend/src/locales/en-US.json
+++ b/studio-frontend/src/locales/en-US.json
@@ -936,6 +936,8 @@
       "upload_permission": "Upload media",
       "summary_permission": "Generate summary",
       "session_permission": "Create session",
+      "microphone_permission": "Create microphone sessions",
+      "bot_permission": "Create bot sessions",
       "update_button": "Update permissions"
     },
     "matching_users": {

--- a/studio-frontend/src/locales/fr-FR.json
+++ b/studio-frontend/src/locales/fr-FR.json
@@ -930,6 +930,8 @@
       "upload_permission": "Publier des médias",
       "summary_permission": "Générer des résumés",
       "session_permission": "Créer des sessions",
+      "microphone_permission": "Créer des sessions microphone",
+      "bot_permission": "Créer des sessions bot",
       "update_button": "Mettre à jour les permissions"
     },
     "matching_users": {

--- a/studio-frontend/src/mixins/organizationPermissions.js
+++ b/studio-frontend/src/mixins/organizationPermissions.js
@@ -1,9 +1,4 @@
-export const PERMISSIONS = Object.freeze({
-  UNDEFINED: 0,
-  UPLOAD: 1,
-  SUMMARY: 2,
-  SESSION: 4,
-})
+import { ORGANIZATION_PERMISSIONS } from "@/const/organizationPermissions"
 
 export const organizationPermissionsMixin = {
   methods: {
@@ -13,23 +8,33 @@ export const organizationPermissionsMixin = {
     hasPermission: (userRight, desiredRight) =>
       (userRight & desiredRight) == desiredRight,
     hasUploadPermission(permission) {
-      return this.hasPermission(permission, PERMISSIONS.UPLOAD)
+      return this.hasPermission(permission, ORGANIZATION_PERMISSIONS.UPLOAD)
     },
     hasSummaryPermission(permission) {
-      return this.hasPermission(permission, PERMISSIONS.SUMMARY)
+      return this.hasPermission(permission, ORGANIZATION_PERMISSIONS.SUMMARY)
     },
     hasSessionPermission(permission) {
-      return this.hasPermission(permission, PERMISSIONS.SESSION)
+      return this.hasPermission(permission, ORGANIZATION_PERMISSIONS.SESSION)
+    },
+    hasMicrophonePermission(permission) {
+      return this.hasPermission(permission, ORGANIZATION_PERMISSIONS.MICROPHONE)
+    },
+    hasBotPermission(permission) {
+      return this.hasPermission(permission, ORGANIZATION_PERMISSIONS.BOT)
     },
     computePermissionsNumber({
       upload = false,
       summary = false,
       session = false,
+      microphone = false,
+      bot = false,
     }) {
       return (
-        (upload ? PERMISSIONS.UPLOAD : 0) +
-        (summary ? PERMISSIONS.SUMMARY : 0) +
-        (session ? PERMISSIONS.SESSION : 0)
+        (upload ? ORGANIZATION_PERMISSIONS.UPLOAD : 0) +
+        (summary ? ORGANIZATION_PERMISSIONS.SUMMARY : 0) +
+        (session ? ORGANIZATION_PERMISSIONS.SESSION : 0) +
+        (microphone ? ORGANIZATION_PERMISSIONS.MICROPHONE : 0) +
+        (bot ? ORGANIZATION_PERMISSIONS.BOT : 0)
       )
     },
   },
@@ -46,6 +51,20 @@ export const organizationPermissionsMixin = {
     },
     canSessionInCurrentOrganization() {
       return this.hasSessionPermission(this.organizationPermissions)
+    },
+    canMicrophoneInCurrentOrganization() {
+      return this.hasMicrophonePermission(this.organizationPermissions)
+    },
+    canBotInCurrentOrganization() {
+      return this.hasBotPermission(this.organizationPermissions)
+    },
+    canStartConversationInCurrentOrganization() {
+      return (
+        this.canUploadInCurrentOrganization ||
+        this.canSessionInCurrentOrganization ||
+        this.canMicrophoneInCurrentOrganization ||
+        this.canBotInCurrentOrganization
+      )
     },
   },
 }

--- a/studio-frontend/src/views/ConversationsCreate.vue
+++ b/studio-frontend/src/views/ConversationsCreate.vue
@@ -198,7 +198,14 @@ export default {
     canCreateSession() {
       const enableSession = getEnv("VUE_APP_ENABLE_SESSION") === "true"
 
-      return enableSession && this.canSessionInCurrentOrganization
+      // True when the org has at least one session-related permission
+      // (SESSION, MICROPHONE, or BOT). Each tab is gated by its own permission below.
+      return (
+        enableSession &&
+        (this.canSessionInCurrentOrganization ||
+          this.canMicrophoneInCurrentOrganization ||
+          this.canBotInCurrentOrganization)
+      )
     },
     loadingSessionData() {
       return (
@@ -231,32 +238,41 @@ export default {
         )
       }
 
-      if (this.canCreateSession) {
-        const loading = this.loadingSessionData
-        if (this.isAtLeastQuickMeeting) {
-          res.push({
-            name: "live",
-            label: this.$t("conversation_creation.tabs.quick_meeting"),
-            icon: "microphone",
-            disabled:
-              this.transcriberProfilesQuickMeeting.length === 0 || loading,
-          })
-          res.push({
-            name: "visio",
-            label: this.$t("conversation_creation.tabs.visio"),
-            icon: "webcam",
-            disabled:
-              this.transcriberProfilesQuickMeeting.length === 0 || loading,
-          })
-        }
-        if (this.isAtLeastMeetingManager) {
-          res.push({
-            name: "session",
-            label: this.$i18n.t("conversation_creation.tabs.session"),
-            icon: "plugs-connected",
-            disabled: this.transcriberProfiles.length === 0 || loading,
-          })
-        }
+      if (!this.canCreateSession) return res
+
+      const loading = this.loadingSessionData
+      const quickMeetingDisabled =
+        this.transcriberProfilesQuickMeeting.length === 0 || loading
+
+      if (
+        this.isAtLeastQuickMeeting &&
+        this.canMicrophoneInCurrentOrganization
+      ) {
+        res.push({
+          name: "live",
+          label: this.$t("conversation_creation.tabs.quick_meeting"),
+          icon: "microphone",
+          disabled: quickMeetingDisabled,
+        })
+      }
+      if (this.isAtLeastQuickMeeting && this.canBotInCurrentOrganization) {
+        res.push({
+          name: "visio",
+          label: this.$t("conversation_creation.tabs.visio"),
+          icon: "webcam",
+          disabled: quickMeetingDisabled,
+        })
+      }
+      if (
+        this.isAtLeastMeetingManager &&
+        this.canSessionInCurrentOrganization
+      ) {
+        res.push({
+          name: "session",
+          label: this.$i18n.t("conversation_creation.tabs.session"),
+          icon: "plugs-connected",
+          disabled: this.transcriberProfiles.length === 0 || loading,
+        })
       }
 
       return res

--- a/studio-websocket/package.json
+++ b/studio-websocket/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linto-studio-websocket",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "Websocker server for the conversation manager.",
   "main": "src/app.js",
   "type": "module",


### PR DESCRIPTION
Separate "microphone" and "bot" rights from the "session" permission. The organization-level SESSION permission currently covers microphone access, bot access, and session API access all at once. This PR splits it into distinct rights for granular access control.

Permissions (bitmask)
  - MICROPHONE (4) — live microphone sessions (quick meetings)
  - BOT (8) — bot-based live sessions (video conferencing)
  - SESSION (16) — session API access for templates/management (formerly bit 4)
