### PR TITLE
JS SDK parity with Python: taxonomy, LLM summary, sharing, exports + tests

### DIFF
--- a/studio-sdk/README.md
+++ b/studio-sdk/README.md
@@ -24,7 +24,7 @@ npm install @linto-ai/linto
 <script type="module" src="https://unpkg.com/@linto-ai/linto/index.js"></script>
 ```
 
-## How to use
+## Quick start
 
 ### NodeJS or Web browser
 
@@ -105,17 +105,17 @@ handle.on("done", on_done)
 handle.on("error", on_error)
 ```
 
-See complete python script at [python/test.js](python/test.py)
+See complete python script at [python/test.py](python/test.py)
 
-## Documentation
+## API reference
 
-_Options in camelCase are the same in pascal_case for Python_
+_Method names and options in `camelCase` are the same in `snake_case` for Python (e.g. `enableDiarization` → `enable_diarization`, `setConversationOwner` → `set_conversation_owner`)._
 
 ### Initialisation
 
 ```javascript
 // Javascript
-linTO = new LinTO({authToken = "auth_token", ...options})
+const linTO = new LinTO({ authToken: "auth_token", ...options })
 ```
 
 ```python
@@ -130,7 +130,13 @@ linTO = LinTO(auth_token="auth_token", **options)
 | authToken | yes      | String | Studio auth token   |                                |
 | baseUrl   | no       | String | Studio API base url | https://studio.linto.ai/cm-api |
 
-### Transcribe
+---
+
+### Transcription
+
+#### transcribe
+
+Upload a media file and start a transcription job. Returns a polling handle that emits `update`, `done`, and `error` events.
 
 ```javascript
 // Javascript
@@ -143,23 +149,426 @@ handle.addEventListener("error", callback)
 
 ```python
 # Python
-await linTO.transcribe(file, **options)
+handle = await linTO.transcribe(file, **options)
 
 handle.on("update", callback)
 handle.on("done", callback)
 handle.on("error", callback)
 ```
 
-#### Options
-
 | Parameter         | required | value                           | description                                                                              | default value           |
 | ----------------- | -------- | ------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------- |
 | file              | yes      | File or Blob                    | Audio file to transcribe                                                                 |                         |
 | enableDiarization | no       | Bool                            | Enable speaker diarization                                                               | True                    |
-| numberOfSpeaker   | no       | Int                             | Number of speaker for diarization, 0 means auto                                          | 0                       |
+| numberOfSpeaker   | no       | Int                             | Number of speakers for diarization, 0 means auto                                         | 0                       |
 | language          | no       | 2 letters language code or "\*" | Language the audio should be transcribed. "\*" means auto-detection + multiple languages | "\*"                    |
 | enablePunctuation | no       | Bool                            | Enable automatic punctuation recognition                                                 | True                    |
 | name              | no       | String                          | Name of the media in LinTO Studio                                                        | "imported file ${date}" |
+| membersRight      | no       | Int                             | Default permission bitmask for organization members on the resulting conversation (1 = read) | None                |
+
+#### listServices
+
+List ASR (speech-to-text) services available to the current account. Each service exposes a `service_name` field that can be referenced elsewhere.
+
+```javascript
+// Javascript
+const services = await linTO.listServices()
+```
+
+```python
+# Python
+services = await linTO.list_services()
+```
+
+---
+
+### LLM summaries
+
+#### listLlmServices
+
+List LLM services available for summarization.
+
+```javascript
+// Javascript
+const services = await linTO.listLlmServices()
+```
+
+```python
+# Python
+services = await linTO.list_llm_services()
+```
+
+#### summarize
+
+Trigger an LLM summary and return a polling handle. Events are the same shape as `transcribe`: `update`, `done` (with `{ content, jobId }`), `error`.
+
+```javascript
+// Javascript
+const handle = await linTO.summarize(conversationId, serviceRoute, { ...options })
+
+handle.addEventListener("done", (e) => console.log(e.detail.content))
+```
+
+```python
+# Python
+handle = await linTO.summarize(conversation_id, service_route, **options)
+
+handle.on("done", lambda e: print(e["content"]))
+```
+
+| Parameter      | required | value  | description                                            | default value |
+| -------------- | -------- | ------ | ------------------------------------------------------ | ------------- |
+| conversationId | yes      | String | Target conversation id                                 |               |
+| serviceRoute   | yes      | String | LLM service route (see `listLlmServices`)              |               |
+| flavor         | no       | String | Optional flavor / preset name                          | None          |
+
+---
+
+### Export & download
+
+#### downloadConversation
+
+Download the raw transcription (no LLM step). Binary formats (`docx`, `odt`, `verbatim`) return a Blob (browser) or ArrayBuffer (Node); other formats return JSON.
+
+```javascript
+// Javascript
+const blob = await linTO.downloadConversation(conversationId, { format: "docx" })
+```
+
+```python
+# Python
+content = await linTO.download_conversation(conversation_id, format="docx")
+```
+
+| Parameter      | required | value  | description                       | default value |
+| -------------- | -------- | ------ | --------------------------------- | ------------- |
+| conversationId | yes      | String | Target conversation id            |               |
+| format         | no       | String | `"docx"`, `"odt"`, `"json"`, ...  | "docx"        |
+
+#### getExportList
+
+List existing export jobs attached to a conversation.
+
+```javascript
+// Javascript
+const jobs = await linTO.getExportList(conversationId)
+```
+
+```python
+# Python
+jobs = await linTO.get_export_list(conversation_id)
+```
+
+#### getExportContent
+
+Fetch the content of a finished export job.
+
+```javascript
+// Javascript
+const content = await linTO.getExportContent(conversationId, jobId)
+```
+
+```python
+# Python
+content = await linTO.get_export_content(conversation_id, job_id)
+```
+
+#### getPublicationTemplates
+
+List publication templates available on the organization.
+
+```javascript
+// Javascript
+const templates = await linTO.getPublicationTemplates()
+```
+
+```python
+# Python
+templates = await linTO.get_publication_templates()
+```
+
+#### getTemplatePlaceholders
+
+Get placeholders defined on a publication template.
+
+```javascript
+// Javascript
+const placeholders = await linTO.getTemplatePlaceholders(templateId)
+```
+
+```python
+# Python
+placeholders = await linTO.get_template_placeholders(template_id)
+```
+
+#### exportWithTemplate
+
+Render a publication template to a downloadable document.
+
+```javascript
+// Javascript
+const file = await linTO.exportWithTemplate(jobId, { ...options })
+```
+
+```python
+# Python
+file = await linTO.export_with_template(job_id, **options)
+```
+
+| Parameter     | required | value  | description                | default value |
+| ------------- | -------- | ------ | -------------------------- | ------------- |
+| jobId         | yes      | String | Source export job id       |               |
+| format        | no       | String | Output format              | "pdf"         |
+| templateId    | no       | String | Publication template id    | None          |
+| versionNumber | no       | Int    | Template version           | None          |
+
+---
+
+### Taxonomy
+
+A LinTO Studio organization can group media in two complementary ways:
+
+- **Categories & tags**: a category holds a flat list of tags; each conversation can carry any number of tags. The built-in `"tags"` category is the one whose entries surface as chips on media cards.
+- **Folders**: a hierarchical tree; each conversation can live in at most one folder.
+
+#### listCategories
+
+List taxonomy categories on the current organization.
+
+```javascript
+// Javascript
+const categories = await linTO.listCategories()
+```
+
+```python
+# Python
+categories = await linTO.list_categories()
+```
+
+#### listTags
+
+List tags inside a category.
+
+```javascript
+// Javascript
+const tags = await linTO.listTags(categoryId)
+```
+
+```python
+# Python
+tags = await linTO.list_tags(category_id)
+```
+
+#### createTag
+
+Create a tag inside a category.
+
+```javascript
+// Javascript
+const tag = await linTO.createTag(categoryId, name, { ...options })
+```
+
+```python
+# Python
+tag = await linTO.create_tag(category_id, name, **options)
+```
+
+| Parameter  | required | value  | description    | default value |
+| ---------- | -------- | ------ | -------------- | ------------- |
+| categoryId | yes      | String | Parent category|               |
+| name       | yes      | String | Tag name       |               |
+| color      | no       | String | Hex color      | None          |
+| emoji      | no       | String | Unicode emoji  | None          |
+
+#### ensureTag
+
+Return the id of tag `name`, creating it if needed. Defaults to the built-in `"tags"` category, falling back to the first available category if the named one is missing. Returns `null` when no category exists at all.
+
+```javascript
+// Javascript
+const tagId = await linTO.ensureTag("important")
+await linTO.addConversationTag(conversationId, tagId)
+```
+
+```python
+# Python
+tag_id = await linTO.ensure_tag("important")
+await linTO.add_conversation_tag(conversation_id, tag_id)
+```
+
+| Parameter    | required | value  | description                                          | default value |
+| ------------ | -------- | ------ | ---------------------------------------------------- | ------------- |
+| name         | yes      | String | Tag name (case-insensitive lookup)                   |               |
+| categoryName | no       | String | Category to look into                                | "tags"        |
+| color        | no       | String | Color used if the tag has to be created              | None          |
+| emoji        | no       | String | Emoji used if the tag has to be created              | None          |
+
+#### addConversationTag
+
+Append a tag to a conversation, preserving existing tags.
+
+```javascript
+// Javascript
+await linTO.addConversationTag(conversationId, tagId)
+```
+
+```python
+# Python
+await linTO.add_conversation_tag(conversation_id, tag_id)
+```
+
+#### listFolders
+
+List folders on the current organization.
+
+```javascript
+// Javascript
+const folders = await linTO.listFolders()
+```
+
+```python
+# Python
+folders = await linTO.list_folders()
+```
+
+#### createFolder
+
+Create a folder.
+
+```javascript
+// Javascript
+const folder = await linTO.createFolder(name, { ...options })
+```
+
+```python
+# Python
+folder = await linTO.create_folder(name, **options)
+```
+
+| Parameter  | required | value                  | description                                          | default value |
+| ---------- | -------- | ---------------------- | ---------------------------------------------------- | ------------- |
+| name       | yes      | String                 | Folder name                                          |               |
+| parentId   | no       | String                 | Parent folder id (root if omitted)                   | None          |
+| color      | no       | String                 | Hex color                                            | None          |
+| emoji      | no       | String                 | Unicode emoji                                        | None          |
+| visibility | no       | `"public"` / `"private"` | Folder visibility for members below MAINTAINER      | "public"      |
+
+#### ensureFolder
+
+Return the id of folder `name`, creating it if needed. Matches on `(name, parentId)` so the same name at different levels stays distinct. With `visibility: "private"`, the service account becomes the owner and moved conversations are hidden from members below MAINTAINER.
+
+```javascript
+// Javascript
+const folderId = await linTO.ensureFolder(name, { ...options })
+```
+
+```python
+# Python
+folder_id = await linTO.ensure_folder(name, **options)
+```
+
+| Parameter  | required | value                  | description                                          | default value |
+| ---------- | -------- | ---------------------- | ---------------------------------------------------- | ------------- |
+| name       | yes      | String                 | Folder name                                          |               |
+| parentId   | no       | String                 | Match within this parent folder (root if omitted)    | None          |
+| visibility | no       | `"public"` / `"private"` | Visibility used if the folder has to be created     | "public"      |
+
+#### moveToFolder
+
+Move a conversation into a folder.
+
+```javascript
+// Javascript
+await linTO.moveToFolder(folderId, conversationId)
+```
+
+```python
+# Python
+await linTO.move_to_folder(folder_id, conversation_id)
+```
+
+---
+
+### Sharing & users
+
+#### shareConversation
+
+Share a conversation with a user by email. By default LinTO Studio sends a notification email — pass `notify: false` to suppress it.
+
+```javascript
+// Javascript
+await linTO.shareConversation(conversationId, email, { ...options })
+```
+
+```python
+# Python
+await linTO.share_conversation(conversation_id, email, **options)
+```
+
+| Parameter      | required | value  | description                              | default value |
+| -------------- | -------- | ------ | ---------------------------------------- | ------------- |
+| conversationId | yes      | String | Target conversation id                   |               |
+| email          | yes      | String | Recipient email                          |               |
+| right          | no       | Int    | Permission bitmask (1 = read)            | 1             |
+| notify         | no       | Bool   | Send notification email                  | True          |
+
+#### searchUsers
+
+Search users by email or display name. Mostly useful as a building block for higher-level helpers like `setConversationOwner`.
+
+```javascript
+// Javascript
+const users = await linTO.searchUsers(search)
+```
+
+```python
+# Python
+users = await linTO.search_users(search)
+```
+
+#### updateConversation
+
+Patch arbitrary conversation fields (e.g. `owner`, `sharedWithUsers`, `tags`). Mostly useful as a building block — prefer the specialized helpers when one exists.
+
+```javascript
+// Javascript
+await linTO.updateConversation(conversationId, { owner: userId, tags: [tagId] })
+```
+
+```python
+# Python
+await linTO.update_conversation(conversation_id, {"owner": user_id, "tags": [tag_id]})
+```
+
+#### setConversationOwner
+
+Transfer conversation ownership to the user matching `email`. Resolves the user via `searchUsers`, then sets `owner` and clears `sharedWithUsers`. Returns the resolved user id, or `null` if the email cannot be matched.
+
+```javascript
+// Javascript
+const userId = await linTO.setConversationOwner(conversationId, "alice@example.com")
+if (!userId) console.warn("user not found")
+```
+
+```python
+# Python
+user_id = await linTO.set_conversation_owner(conversation_id, "alice@example.com")
+if not user_id:
+    print("user not found")
+```
+
+---
+
+### Media output
+
+The object emitted on the `done` event of `transcribe` exposes the helpers below.
+
+| Property / method | description                                                                          |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| `fullText`        | Plain text of the full transcript (no speaker, language or timestamp metadata).       |
+| `turns`           | Array of `{ speaker, lang, text, stime, etime }` objects.                            |
+| `response`        | Raw API response (escape hatch for fields the SDK doesn't surface).                  |
+| `toFormat(opts)`  | Render the transcript as a single string with configurable metadata and separators.  |
 
 #### toFormat options
 

--- a/studio-sdk/javascript/index.js
+++ b/studio-sdk/javascript/index.js
@@ -1,7 +1,19 @@
 import { StudioApiService } from "./src/services/studioApiService.js"
 import { PollingService } from "./src/services/pollingService.js"
 import { SummaryPollingService } from "./src/services/summaryPollingService.js"
+
+/**
+ * High-level client for the LinTO Studio API.
+ *
+ * Wraps the lower-level {@link StudioApiService} and exposes convenience
+ * helpers for transcription, LLM summaries, taxonomy, sharing, and exports.
+ */
 class LinTO {
+  /**
+   * @param {Object} options
+   * @param {string} options.authToken - LinTO Studio bearer token.
+   * @param {string} [options.baseUrl="https://studio.linto.ai/cm-api"] - Base URL of the studio-api gateway.
+   */
   constructor({ authToken, baseUrl = "https://studio.linto.ai/cm-api" } = {}) {
     this.baseUrl = baseUrl
     this.apiService = new StudioApiService({
@@ -10,6 +22,24 @@ class LinTO {
     })
   }
 
+  /**
+   * Upload a media file and start a transcription job.
+   *
+   * @param {Blob|Buffer|File} file - Media payload to upload.
+   * @param {Object} [options]
+   * @param {boolean} [options.enableDiarization=true] - Run speaker diarization.
+   * @param {string} [options.numberOfSpeaker="0"] - Expected speaker count, "0" = auto.
+   * @param {boolean} [options.enablePunctuation=true] - Apply punctuation post-processing.
+   * @param {string} [options.language="*"] - BCP-47 language code or "*" for auto-detect.
+   * @param {string} [options.quality] - Service quality tier.
+   * @param {string} [options.modelType] - ASR model identifier.
+   * @param {string} [options.name] - Display name of the resulting conversation.
+   * @param {string} [options.serviceName] - Force a specific ASR service.
+   * @param {string} [options.endpointAsr] - Override ASR endpoint URL.
+   * @param {string} [options.diarizationServiceName] - Force a diarization service.
+   * @param {string} [options.punctuationServiceName] - Force a punctuation service.
+   * @returns {Promise<PollingService>} Polling handle emitting "update", "done", "error".
+   */
   async transcribe(
     file,
     {
@@ -44,6 +74,11 @@ class LinTO {
     return new PollingService(mediaId, this.apiService)
   }
 
+  /**
+   * List ASR (speech-to-text) services available to the current account.
+   *
+   * @returns {Promise<Array<Object>>} Services with a `service_name` field.
+   */
   async listServices() {
     const services = await this.apiService.fetchAsrServices()
     return services.map((service) => {
@@ -53,10 +88,28 @@ class LinTO {
     })
   }
 
+  /**
+   * List LLM services available for summarization.
+   *
+   * @returns {Promise<Array<Object>>}
+   */
   async listLlmServices() {
     return await this.apiService.fetchLlmServices()
   }
 
+  /**
+   * Trigger an LLM summary and return a polling handle.
+   *
+   * @param {string} conversationId - Target conversation id.
+   * @param {string} serviceRoute - LLM service route (see {@link LinTO#listLlmServices}).
+   * @param {Object} [options]
+   * @param {string} [options.flavor] - Optional flavor / preset name.
+   * @returns {Promise<SummaryPollingService>} Handle emitting "update", "done", "error".
+   * @example
+   * const services = await linto.listLlmServices()
+   * const summary = await linto.summarize(convId, services[0].route, { flavor: "concise" })
+   * summary.addEventListener("done", (e) => console.log(e.detail.content))
+   */
   async summarize(conversationId, serviceRoute, { flavor } = {}) {
     await this.apiService.triggerSummary({
       conversationId,
@@ -68,14 +121,35 @@ class LinTO {
 
   // --- Exports / Download / Publication ---
 
+  /**
+   * List existing export jobs for a conversation.
+   *
+   * @param {string} conversationId
+   * @returns {Promise<Array<Object>>}
+   */
   async getExportList(conversationId) {
     return await this.apiService.getExportList({ conversationId })
   }
 
+  /**
+   * Fetch the content of a finished export job.
+   *
+   * @param {string} conversationId
+   * @param {string} jobId
+   * @returns {Promise<*>} Binary content or structured data depending on format.
+   */
   async getExportContent(conversationId, jobId) {
     return await this.apiService.getExportContent({ conversationId, jobId })
   }
 
+  /**
+   * Download the raw transcription (no LLM step).
+   *
+   * @param {string} conversationId
+   * @param {Object} [options]
+   * @param {string} [options.format="docx"] - "docx", "odt", "json", etc.
+   * @returns {Promise<*>} Binary content for docx/odt, object for json.
+   */
   async downloadConversation(conversationId, { format = "docx" } = {}) {
     return await this.apiService.downloadConversation({
       conversationId,
@@ -83,14 +157,35 @@ class LinTO {
     })
   }
 
+  /**
+   * List publication templates available on the organization.
+   *
+   * @returns {Promise<Array<Object>>}
+   */
   async getPublicationTemplates() {
     return await this.apiService.getPublicationTemplates()
   }
 
+  /**
+   * Get placeholders defined on a publication template.
+   *
+   * @param {string} templateId
+   * @returns {Promise<Array<Object>>}
+   */
   async getTemplatePlaceholders(templateId) {
     return await this.apiService.getTemplatePlaceholders({ templateId })
   }
 
+  /**
+   * Render a publication template to a downloadable document.
+   *
+   * @param {string} jobId - Source export job id.
+   * @param {Object} [options]
+   * @param {string} [options.format="pdf"] - Output format.
+   * @param {string} [options.templateId] - Publication template id.
+   * @param {number} [options.versionNumber] - Template version.
+   * @returns {Promise<*>} Binary content.
+   */
   async exportWithTemplate(
     jobId,
     { format = "pdf", templateId, versionNumber } = {}
@@ -105,18 +200,56 @@ class LinTO {
 
   // --- Taxonomy: categories, tags, folders ---
 
+  /**
+   * List taxonomy categories on the current organization.
+   *
+   * @returns {Promise<Array<Object>>}
+   */
   async listCategories() {
     return await this.apiService.listCategories()
   }
 
+  /**
+   * List tags inside a category.
+   *
+   * @param {string} categoryId
+   * @returns {Promise<Array<Object>>}
+   */
   async listTags(categoryId) {
     return await this.apiService.listTags({ categoryId })
   }
 
+  /**
+   * Create a tag inside a category.
+   *
+   * @param {string} categoryId
+   * @param {string} name
+   * @param {Object} [options]
+   * @param {string} [options.color]
+   * @param {string} [options.emoji]
+   * @returns {Promise<Object>} Created tag.
+   */
   async createTag(categoryId, name, { color, emoji } = {}) {
     return await this.apiService.createTag({ categoryId, name, color, emoji })
   }
 
+  /**
+   * Return the id of tag `name`, creating it if needed.
+   *
+   * Defaults to the built-in `"tags"` category (whose entries surface as chips
+   * on media cards). Falls back to the first available category if the named
+   * one is missing. Returns `null` if no category exists at all.
+   *
+   * @param {string} name - Tag name (case-insensitive lookup).
+   * @param {Object} [options]
+   * @param {string} [options.categoryName="tags"]
+   * @param {string} [options.color]
+   * @param {string} [options.emoji]
+   * @returns {Promise<string|null>} Tag id, or null on failure.
+   * @example
+   * const tagId = await linto.ensureTag("important")
+   * await linto.addConversationTag(convId, tagId)
+   */
   async ensureTag(name, { categoryName = "tags", color, emoji } = {}) {
     const categories = await this.listCategories()
     if (!Array.isArray(categories) || categories.length === 0) {
@@ -156,6 +289,13 @@ class LinTO {
     return null
   }
 
+  /**
+   * Append a tag to a conversation, preserving existing tags.
+   *
+   * @param {string} conversationId
+   * @param {string} tagId
+   * @returns {Promise<Array<string>|null>} The new tag id list, or null if `tagId` is falsy.
+   */
   async addConversationTag(conversationId, tagId) {
     if (!tagId) {
       return null
@@ -179,10 +319,29 @@ class LinTO {
     return newTags
   }
 
+  /**
+   * List folders on the current organization.
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.tree=false] - Return nested tree structure.
+   * @param {boolean} [options.withConversationCount=false] - Include conversation counts.
+   * @returns {Promise<Array<Object>>}
+   */
   async listFolders({ tree = false, withConversationCount = false } = {}) {
     return await this.apiService.listFolders({ tree, withConversationCount })
   }
 
+  /**
+   * Create a folder.
+   *
+   * @param {string} name
+   * @param {Object} [options]
+   * @param {string} [options.parentId] - Parent folder id (root if omitted).
+   * @param {string} [options.color]
+   * @param {string} [options.emoji]
+   * @param {string} [options.visibility="public"] - "public" or "private".
+   * @returns {Promise<Object>} Created folder.
+   */
   async createFolder(
     name,
     { parentId, color, emoji, visibility = "public" } = {}
@@ -196,6 +355,19 @@ class LinTO {
     })
   }
 
+  /**
+   * Return folder id for `name`, creating it if missing.
+   *
+   * Matches on `(name, parentId)` so the same name at different levels stays
+   * distinct. With `visibility: "private"`, the service account becomes the
+   * owner and moved conversations are hidden from members below MAINTAINER.
+   *
+   * @param {string} name
+   * @param {Object} [options]
+   * @param {string} [options.parentId] - Match within this parent (root if omitted).
+   * @param {string} [options.visibility="public"]
+   * @returns {Promise<string|null>} Folder id, or null on failure.
+   */
   async ensureFolder(name, { parentId, visibility = "public" } = {}) {
     const folders = await this.listFolders()
     if (Array.isArray(folders)) {
@@ -218,6 +390,13 @@ class LinTO {
     return null
   }
 
+  /**
+   * Move a conversation into a folder.
+   *
+   * @param {string} folderId
+   * @param {string} conversationId
+   * @returns {Promise<*>}
+   */
   async moveToFolder(folderId, conversationId) {
     return await this.apiService.moveConversationToFolder({
       folderId,
@@ -227,6 +406,19 @@ class LinTO {
 
   // --- Sharing & user management ---
 
+  /**
+   * Share a conversation with a user by email.
+   *
+   * By default LinTO Studio sends a notification email. Pass `notify: false`
+   * to suppress it.
+   *
+   * @param {string} conversationId
+   * @param {string} email
+   * @param {Object} [options]
+   * @param {number} [options.right=1] - Permission level bitmask (1 = read).
+   * @param {boolean} [options.notify=true]
+   * @returns {Promise<*>}
+   */
   async shareConversation(conversationId, email, { right = 1, notify = true } = {}) {
     return await this.apiService.shareConversation({
       conversationId,
@@ -236,14 +428,41 @@ class LinTO {
     })
   }
 
+  /**
+   * Search users by email or display name.
+   *
+   * @param {string} search
+   * @returns {Promise<Array<Object>>}
+   */
   async searchUsers(search) {
     return await this.apiService.searchUsers({ search })
   }
 
+  /**
+   * Patch arbitrary conversation fields.
+   *
+   * @param {string} conversationId
+   * @param {Object} data - Fields to update (e.g. `owner`, `sharedWithUsers`, `tags`).
+   * @returns {Promise<*>}
+   */
   async updateConversation(conversationId, data) {
     return await this.apiService.updateConversation({ conversationId, data })
   }
 
+  /**
+   * Transfer conversation ownership to the user matching `email`.
+   *
+   * Resolves the user via {@link LinTO#searchUsers}, then sets `owner` and
+   * clears `sharedWithUsers`. Returns the resolved user id, or `null` if the
+   * email cannot be matched.
+   *
+   * @param {string} conversationId
+   * @param {string} email
+   * @returns {Promise<string|null>}
+   * @example
+   * const userId = await linto.setConversationOwner(convId, "alice@example.com")
+   * if (!userId) console.warn("user not found")
+   */
   async setConversationOwner(conversationId, email) {
     const users = await this.searchUsers(email)
     if (!users || !Array.isArray(users) || users.length === 0) {

--- a/studio-sdk/javascript/index.js
+++ b/studio-sdk/javascript/index.js
@@ -1,5 +1,6 @@
 import { StudioApiService } from "./src/services/studioApiService.js"
 import { PollingService } from "./src/services/pollingService.js"
+import { SummaryPollingService } from "./src/services/summaryPollingService.js"
 class LinTO {
   constructor({ authToken, baseUrl = "https://studio.linto.ai/cm-api" } = {}) {
     this.baseUrl = baseUrl
@@ -50,6 +51,19 @@ class LinTO {
       delete s.serviceName
       return s
     })
+  }
+
+  async listLlmServices() {
+    return await this.apiService.fetchLlmServices()
+  }
+
+  async summarize(conversationId, serviceRoute, { flavor } = {}) {
+    await this.apiService.triggerSummary({
+      conversationId,
+      format: serviceRoute,
+      flavor,
+    })
+    return new SummaryPollingService(conversationId, serviceRoute, this.apiService)
   }
 }
 

--- a/studio-sdk/javascript/index.js
+++ b/studio-sdk/javascript/index.js
@@ -65,6 +65,128 @@ class LinTO {
     })
     return new SummaryPollingService(conversationId, serviceRoute, this.apiService)
   }
+
+  // --- Taxonomy: categories, tags, folders ---
+
+  async listCategories() {
+    return await this.apiService.listCategories()
+  }
+
+  async listTags(categoryId) {
+    return await this.apiService.listTags({ categoryId })
+  }
+
+  async createTag(categoryId, name, { color, emoji } = {}) {
+    return await this.apiService.createTag({ categoryId, name, color, emoji })
+  }
+
+  async ensureTag(name, { categoryName = "tags", color, emoji } = {}) {
+    const categories = await this.listCategories()
+    if (!Array.isArray(categories) || categories.length === 0) {
+      return null
+    }
+
+    let cat = null
+    for (const c of categories) {
+      if (
+        String(c?.name ?? "").toLowerCase() === String(categoryName).toLowerCase()
+      ) {
+        cat = c
+        break
+      }
+    }
+    if (cat === null) {
+      cat = categories[0]
+    }
+    const categoryId = String(cat?._id ?? cat?.id ?? "")
+    if (!categoryId) {
+      return null
+    }
+
+    const tags = await this.listTags(categoryId)
+    if (Array.isArray(tags)) {
+      for (const t of tags) {
+        if (String(t?.name ?? "").toLowerCase() === String(name).toLowerCase()) {
+          return String(t?._id ?? t?.id ?? "")
+        }
+      }
+    }
+
+    const created = await this.createTag(categoryId, name, { color, emoji })
+    if (created && typeof created === "object") {
+      return String(created._id ?? created.id ?? "") || null
+    }
+    return null
+  }
+
+  async addConversationTag(conversationId, tagId) {
+    if (!tagId) {
+      return null
+    }
+    const conv = await this.apiService.getConversation({ conversationId })
+    let existing = []
+    if (conv && typeof conv === "object") {
+      const raw = conv.tags ?? []
+      if (Array.isArray(raw)) {
+        existing = raw.filter((t) => t).map((t) => String(t))
+      }
+    }
+    if (existing.includes(tagId)) {
+      return existing
+    }
+    const newTags = [...existing, tagId]
+    await this.apiService.updateConversation({
+      conversationId,
+      data: { tags: newTags },
+    })
+    return newTags
+  }
+
+  async listFolders({ tree = false, withConversationCount = false } = {}) {
+    return await this.apiService.listFolders({ tree, withConversationCount })
+  }
+
+  async createFolder(
+    name,
+    { parentId, color, emoji, visibility = "public" } = {}
+  ) {
+    return await this.apiService.createFolder({
+      name,
+      parentId,
+      color,
+      emoji,
+      visibility,
+    })
+  }
+
+  async ensureFolder(name, { parentId, visibility = "public" } = {}) {
+    const folders = await this.listFolders()
+    if (Array.isArray(folders)) {
+      for (const f of folders) {
+        const folderParent = f?.parentId ?? null
+        const targetParent = parentId ?? null
+        if (
+          String(f?.name ?? "").toLowerCase() === String(name).toLowerCase() &&
+          folderParent === targetParent
+        ) {
+          return String(f?._id ?? f?.id ?? "")
+        }
+      }
+    }
+
+    const created = await this.createFolder(name, { parentId, visibility })
+    if (created && typeof created === "object") {
+      return String(created._id ?? created.id ?? "") || null
+    }
+    return null
+  }
+
+  async moveToFolder(folderId, conversationId) {
+    return await this.apiService.moveConversationToFolder({
+      folderId,
+      conversationId,
+    })
+  }
 }
 
 try {

--- a/studio-sdk/javascript/index.js
+++ b/studio-sdk/javascript/index.js
@@ -1,6 +1,8 @@
 import { StudioApiService } from "./src/services/studioApiService.js"
 import { PollingService } from "./src/services/pollingService.js"
 import { SummaryPollingService } from "./src/services/summaryPollingService.js"
+import { getId } from "./src/tools/getId.js"
+import { equalsIgnoreCase } from "./src/tools/equalsIgnoreCase.js"
 
 /**
  * High-level client for the LinTO Studio API.
@@ -252,41 +254,22 @@ class LinTO {
    */
   async ensureTag(name, { categoryName = "tags", color, emoji } = {}) {
     const categories = await this.listCategories()
-    if (!Array.isArray(categories) || categories.length === 0) {
-      return null
-    }
+    if (!Array.isArray(categories) || categories.length === 0) return null
 
-    let cat = null
-    for (const c of categories) {
-      if (
-        String(c?.name ?? "").toLowerCase() === String(categoryName).toLowerCase()
-      ) {
-        cat = c
-        break
-      }
-    }
-    if (cat === null) {
-      cat = categories[0]
-    }
-    const categoryId = String(cat?._id ?? cat?.id ?? "")
-    if (!categoryId) {
-      return null
-    }
+    const cat =
+      categories.find((c) => equalsIgnoreCase(c?.name, categoryName)) ??
+      categories[0]
+    const categoryId = getId(cat)
+    if (!categoryId) return null
 
     const tags = await this.listTags(categoryId)
-    if (Array.isArray(tags)) {
-      for (const t of tags) {
-        if (String(t?.name ?? "").toLowerCase() === String(name).toLowerCase()) {
-          return String(t?._id ?? t?.id ?? "")
-        }
-      }
-    }
+    const existing = Array.isArray(tags)
+      ? tags.find((t) => equalsIgnoreCase(t?.name, name))
+      : null
+    if (existing) return getId(existing)
 
     const created = await this.createTag(categoryId, name, { color, emoji })
-    if (created && typeof created === "object") {
-      return String(created._id ?? created.id ?? "") || null
-    }
-    return null
+    return getId(created) || null
   }
 
   /**
@@ -370,24 +353,17 @@ class LinTO {
    */
   async ensureFolder(name, { parentId, visibility = "public" } = {}) {
     const folders = await this.listFolders()
-    if (Array.isArray(folders)) {
-      for (const f of folders) {
-        const folderParent = f?.parentId ?? null
-        const targetParent = parentId ?? null
-        if (
-          String(f?.name ?? "").toLowerCase() === String(name).toLowerCase() &&
-          folderParent === targetParent
-        ) {
-          return String(f?._id ?? f?.id ?? "")
-        }
-      }
-    }
+    const existing = Array.isArray(folders)
+      ? folders.find(
+          (f) =>
+            equalsIgnoreCase(f?.name, name) &&
+            (f?.parentId ?? null) === (parentId ?? null)
+        )
+      : null
+    if (existing) return getId(existing)
 
     const created = await this.createFolder(name, { parentId, visibility })
-    if (created && typeof created === "object") {
-      return String(created._id ?? created.id ?? "") || null
-    }
-    return null
+    return getId(created) || null
   }
 
   /**
@@ -465,22 +441,11 @@ class LinTO {
    */
   async setConversationOwner(conversationId, email) {
     const users = await this.searchUsers(email)
-    if (!users || !Array.isArray(users) || users.length === 0) {
-      return null
-    }
-
-    let userId = null
-    const target = String(email).toLowerCase()
-    for (const u of users) {
-      if (String(u?.email ?? "").toLowerCase() === target) {
-        userId = String(u?._id ?? "")
-        break
-      }
-    }
-
-    if (!userId) {
-      return null
-    }
+    const user = Array.isArray(users)
+      ? users.find((u) => equalsIgnoreCase(u?.email, email))
+      : null
+    const userId = getId(user)
+    if (!userId) return null
 
     await this.updateConversation(conversationId, {
       owner: userId,

--- a/studio-sdk/javascript/index.js
+++ b/studio-sdk/javascript/index.js
@@ -66,6 +66,43 @@ class LinTO {
     return new SummaryPollingService(conversationId, serviceRoute, this.apiService)
   }
 
+  // --- Exports / Download / Publication ---
+
+  async getExportList(conversationId) {
+    return await this.apiService.getExportList({ conversationId })
+  }
+
+  async getExportContent(conversationId, jobId) {
+    return await this.apiService.getExportContent({ conversationId, jobId })
+  }
+
+  async downloadConversation(conversationId, { format = "docx" } = {}) {
+    return await this.apiService.downloadConversation({
+      conversationId,
+      format,
+    })
+  }
+
+  async getPublicationTemplates() {
+    return await this.apiService.getPublicationTemplates()
+  }
+
+  async getTemplatePlaceholders(templateId) {
+    return await this.apiService.getTemplatePlaceholders({ templateId })
+  }
+
+  async exportWithTemplate(
+    jobId,
+    { format = "pdf", templateId, versionNumber } = {}
+  ) {
+    return await this.apiService.exportWithTemplate({
+      jobId,
+      format,
+      templateId,
+      versionNumber,
+    })
+  }
+
   // --- Taxonomy: categories, tags, folders ---
 
   async listCategories() {

--- a/studio-sdk/javascript/index.js
+++ b/studio-sdk/javascript/index.js
@@ -40,6 +40,7 @@ class LinTO {
    * @param {string} [options.endpointAsr] - Override ASR endpoint URL.
    * @param {string} [options.diarizationServiceName] - Force a diarization service.
    * @param {string} [options.punctuationServiceName] - Force a punctuation service.
+   * @param {number} [options.membersRight] - Default permission bitmask for organization members on the resulting conversation.
    * @returns {Promise<PollingService>} Polling handle emitting "update", "done", "error".
    */
   async transcribe(
@@ -56,6 +57,7 @@ class LinTO {
       endpointAsr = null,
       diarizationServiceName = null,
       punctuationServiceName = null,
+      membersRight = null,
     } = {}
   ) {
     const res = await this.apiService.uploadFile({
@@ -71,6 +73,7 @@ class LinTO {
       endpointAsr,
       diarizationServiceName,
       punctuationServiceName,
+      membersRight,
     })
     const mediaId = res.conversationId
     return new PollingService(mediaId, this.apiService)

--- a/studio-sdk/javascript/index.js
+++ b/studio-sdk/javascript/index.js
@@ -187,6 +187,51 @@ class LinTO {
       conversationId,
     })
   }
+
+  // --- Sharing & user management ---
+
+  async shareConversation(conversationId, email, { right = 1, notify = true } = {}) {
+    return await this.apiService.shareConversation({
+      conversationId,
+      email,
+      right,
+      notify,
+    })
+  }
+
+  async searchUsers(search) {
+    return await this.apiService.searchUsers({ search })
+  }
+
+  async updateConversation(conversationId, data) {
+    return await this.apiService.updateConversation({ conversationId, data })
+  }
+
+  async setConversationOwner(conversationId, email) {
+    const users = await this.searchUsers(email)
+    if (!users || !Array.isArray(users) || users.length === 0) {
+      return null
+    }
+
+    let userId = null
+    const target = String(email).toLowerCase()
+    for (const u of users) {
+      if (String(u?.email ?? "").toLowerCase() === target) {
+        userId = String(u?._id ?? "")
+        break
+      }
+    }
+
+    if (!userId) {
+      return null
+    }
+
+    await this.updateConversation(conversationId, {
+      owner: userId,
+      sharedWithUsers: [],
+    })
+    return userId
+  }
 }
 
 try {

--- a/studio-sdk/javascript/package-lock.json
+++ b/studio-sdk/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@linto-ai/linto",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@linto-ai/linto",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "jest": "^29.7.0",

--- a/studio-sdk/javascript/package-lock.json
+++ b/studio-sdk/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@linto-ai/linto",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@linto-ai/linto",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "jest": "^29.7.0",

--- a/studio-sdk/javascript/package-lock.json
+++ b/studio-sdk/javascript/package-lock.json
@@ -1,0 +1,4468 @@
+{
+  "name": "@linto-ai/linto",
+  "version": "1.1.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@linto-ai/linto",
+      "version": "1.1.2",
+      "license": "AGPL-3.0-or-later",
+      "devDependencies": {
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.359",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.359.tgz",
+      "integrity": "sha512-8lPELWuYZIWk7NDvCNthtmMw/7Q5Wu25NpM4djFMHBmk8DubPAtL4YTOp7ou0e7HyJtwkVlWv8XMLURnrtgJQw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/studio-sdk/javascript/package.json
+++ b/studio-sdk/javascript/package.json
@@ -13,7 +13,8 @@
     "Timestamps"
   ],
   "scripts": {
-    "test": "node test.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:example": "node test.js",
     "prepublishOnly": "cp ../README.md ./README.md"
   },
   "repository": {
@@ -26,5 +27,16 @@
     "url": "https://github.com/linto-ai/linto-studio/issues"
   },
   "homepage": "linto.ai",
-  "type": "module"
+  "type": "module",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "transform": {},
+    "testMatch": [
+      "<rootDir>/test/**/*.test.js"
+    ]
+  }
 }

--- a/studio-sdk/javascript/package.json
+++ b/studio-sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linto-ai/linto",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Wrapper around LinTO Studio API",
   "main": "index.js",
   "module": "index.js",

--- a/studio-sdk/javascript/package.json
+++ b/studio-sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linto-ai/linto",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Wrapper around LinTO Studio API",
   "main": "index.js",
   "module": "index.js",

--- a/studio-sdk/javascript/src/request.js
+++ b/studio-sdk/javascript/src/request.js
@@ -1,25 +1,12 @@
 export function prepareRequest(url, method, { token, ...args } = {}) {
-  const defaultQueryParams = {
-    t: Date.now(),
-  }
-
-  const queryParams = new URLSearchParams({
-    ...defaultQueryParams,
-    ...(method === "get" ? data : {}),
-  }).toString()
-
-  const fullUrl = `${url}?${queryParams}`
-
-  const requestObj = new Request(fullUrl, {
+  return new Request(url, {
     method,
     headers: {
       "Content-Type": "application/json",
       Authorization: token ? `Bearer ${token}` : null,
     },
-    body: method != "GET" ? JSON.stringify(args) : null,
+    body: method !== "GET" ? JSON.stringify(args) : null,
   })
-
-  return requestObj
 }
 
 export function prepareMultipartFormData(url, token, formData) {

--- a/studio-sdk/javascript/src/request.js
+++ b/studio-sdk/javascript/src/request.js
@@ -35,10 +35,31 @@ export function prepareMultipartFormData(url, token, formData) {
   return requestObj
 }
 
-export async function sendRequest(request) {
+export async function sendRequest(request, { responseType } = {}) {
   const res = await fetch(request)
   if (!res.ok) {
     throw new Error(`Request failed with status ${res.status}`)
+  }
+  if (res.status === 204) {
+    return null
+  }
+  if (responseType === "binary") {
+    // Prefer Blob in browser-like environments (window present), otherwise
+    // return an ArrayBuffer which is the most portable binary container in
+    // Node. Callers can wrap the result themselves if they need a Buffer.
+    const isBrowser =
+      typeof globalThis !== "undefined" &&
+      typeof globalThis.window !== "undefined" &&
+      typeof globalThis.window.document !== "undefined"
+    if (isBrowser && typeof res.blob === "function") {
+      return await res.blob()
+    }
+    if (typeof res.arrayBuffer === "function") {
+      return await res.arrayBuffer()
+    }
+    if (typeof res.blob === "function") {
+      return await res.blob()
+    }
   }
   return await res.json()
 }

--- a/studio-sdk/javascript/src/services/pollingService.js
+++ b/studio-sdk/javascript/src/services/pollingService.js
@@ -1,27 +1,51 @@
 export class PollingService extends EventTarget {
-  constructor(mediaId, apiService) {
+  #intervalId = null
+
+  constructor(mediaId, apiService, { intervalMs = 1000 } = {}) {
     super()
     this.mediaId = mediaId
     this.apiService = apiService
 
-    this.pollingInterval = setInterval(async () => {
-      const media = await this.apiService.getMediaStatus({ mediaId })
-      const job = media?.jobs?.transcription
+    this.#intervalId = setInterval(async () => {
+      try {
+        const media = await this.apiService.getMediaStatus({ mediaId })
+        const job = media?.jobs?.transcription
 
-      switch (job?.state) {
-        case "done":
-          clearInterval(this.pollingInterval)
-          const media = await this.apiService.getMedia({ mediaId })
-          this.dispatchEvent(new CustomEvent("done", { detail: media }))
-          break
-        case "error":
-          clearInterval(this.pollingInterval)
-          this.dispatchEvent(new Event("error"))
-          break
-        default:
-          this.dispatchEvent(new CustomEvent("update", { detail: job }))
-          break
+        switch (job?.state) {
+          case "done": {
+            const fullMedia = await this.apiService.getMedia({ mediaId })
+            this.#clearInterval()
+            this.dispatchEvent(new CustomEvent("done", { detail: fullMedia }))
+            break
+          }
+          case "error": {
+            this.#clearInterval()
+            this.dispatchEvent(new CustomEvent("error", { detail: job }))
+            break
+          }
+          default:
+            this.dispatchEvent(new CustomEvent("update", { detail: job }))
+            break
+        }
+      } catch (err) {
+        this.#clearInterval()
+        this.dispatchEvent(new CustomEvent("error", { detail: err }))
       }
-    }, 1000)
+    }, intervalMs)
+  }
+
+  stop() {
+    if (this.#intervalId === null) {
+      return
+    }
+    this.#clearInterval()
+    this.dispatchEvent(new CustomEvent("cancelled"))
+  }
+
+  #clearInterval() {
+    if (this.#intervalId !== null) {
+      clearInterval(this.#intervalId)
+      this.#intervalId = null
+    }
   }
 }

--- a/studio-sdk/javascript/src/services/pollingService.js
+++ b/studio-sdk/javascript/src/services/pollingService.js
@@ -1,3 +1,10 @@
+/**
+ * Polls a transcription job until it finishes.
+ *
+ * Emits `update` (in-progress job), `done` (final media), `error` (failure),
+ * and `cancelled` (after `.stop()`). Call `.stop()` once you no longer need
+ * it to clear the underlying interval.
+ */
 export class PollingService extends EventTarget {
   #intervalId = null
 

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -75,6 +75,41 @@ export class StudioApiService {
     })
   }
 
+  // -- Download / Publication methods --
+
+  async downloadConversation({ conversationId, format = "docx" } = {}) {
+    return await this.#withToken(this.#downloadConversation)({
+      conversationId,
+      format,
+    })
+  }
+
+  async getPublicationTemplates(args = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#getPublicationTemplates.bind(this))
+    )(args)
+  }
+
+  async getTemplatePlaceholders({ templateId } = {}) {
+    return await this.#withToken(this.#getTemplatePlaceholders)({
+      templateId,
+    })
+  }
+
+  async exportWithTemplate({
+    jobId,
+    format = "pdf",
+    templateId,
+    versionNumber,
+  } = {}) {
+    return await this.#withToken(this.#exportWithTemplate)({
+      jobId,
+      format,
+      templateId,
+      versionNumber,
+    })
+  }
+
   // -- Taxonomy methods (categories, tags, folders) --
 
   async listCategories(args = {}) {
@@ -322,6 +357,52 @@ export class StudioApiService {
       { token }
     )
     return await sendRequest(req)
+  }
+
+  // -- Download / Publication private implementations --
+
+  async #downloadConversation({ token, conversationId, format }) {
+    const url = `${this.baseApiUrl}/conversations/${conversationId}/download?format=${encodeURIComponent(format)}`
+    const req = prepareRequest(url, "POST", { token })
+    const isBinary =
+      format === "docx" || format === "odt" || format === "verbatim"
+    return await sendRequest(req, {
+      responseType: isBinary ? "binary" : undefined,
+    })
+  }
+
+  async #getPublicationTemplates({ token, organizationId }) {
+    const url = `${this.baseApiUrl}/publication/templates?organization_id=${encodeURIComponent(organizationId)}`
+    const req = prepareRequest(url, "GET", { token })
+    return await sendRequest(req)
+  }
+
+  async #getTemplatePlaceholders({ token, templateId }) {
+    const url = `${this.baseApiUrl}/publication/templates/${templateId}/placeholders`
+    const req = prepareRequest(url, "GET", { token })
+    return await sendRequest(req)
+  }
+
+  async #exportWithTemplate({
+    token,
+    jobId,
+    format,
+    templateId,
+    versionNumber,
+  }) {
+    let url = `${this.baseApiUrl}/publication/${jobId}/export/${format}`
+    const params = []
+    if (templateId !== undefined && templateId !== null && templateId !== "") {
+      params.push(`templateId=${encodeURIComponent(templateId)}`)
+    }
+    if (versionNumber !== undefined && versionNumber !== null) {
+      params.push(`versionNumber=${encodeURIComponent(versionNumber)}`)
+    }
+    if (params.length > 0) {
+      url += `?${params.join("&")}`
+    }
+    const req = prepareRequest(url, "GET", { token })
+    return await sendRequest(req, { responseType: "binary" })
   }
 
   // -- Taxonomy private implementations --

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -75,6 +75,65 @@ export class StudioApiService {
     })
   }
 
+  // -- Taxonomy methods (categories, tags, folders) --
+
+  async listCategories(args = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#listCategories.bind(this))
+    )(args)
+  }
+
+  async listTags({ categoryId } = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#listTags.bind(this))
+    )({ categoryId })
+  }
+
+  async createTag({ categoryId, name, color, emoji, description } = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#createTag.bind(this))
+    )({ categoryId, name, color, emoji, description })
+  }
+
+  async listFolders({ tree = false, withConversationCount = false } = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#listFolders.bind(this))
+    )({ tree, withConversationCount })
+  }
+
+  async createFolder({
+    name,
+    parentId,
+    color,
+    emoji,
+    visibility = "public",
+  } = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#createFolder.bind(this))
+    )({ name, parentId, color, emoji, visibility })
+  }
+
+  async moveConversationToFolder({ folderId, conversationId } = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#moveConversationToFolder.bind(this))
+    )({ folderId, conversationId })
+  }
+
+  async getConversation({ conversationId } = {}) {
+    return await this.#withToken(this.#getConversation)({ conversationId })
+  }
+
+  async searchUsers({ search } = {}) {
+    return await this.#withToken(this.#searchUsers)({ search })
+  }
+
+  async updateConversation({ conversationId, data } = {}) {
+    return await this.#withToken(this.#updateConversation)({
+      conversationId,
+      data,
+    })
+  }
+
   async login({ email, password }) {
     const req = prepareRequest(`${this.baseAuthUrl}/login`, "POST", {
       email,
@@ -249,6 +308,126 @@ export class StudioApiService {
       { token }
     )
     return await sendRequest(req)
+  }
+
+  // -- Taxonomy private implementations --
+
+  async #listCategories({ token, organizationId }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/categories`,
+      "GET",
+      { token }
+    )
+    return await sendRequest(req)
+  }
+
+  async #listTags({ token, organizationId, categoryId }) {
+    const url = `${this.baseApiUrl}/organizations/${organizationId}/tags?categoryId=${encodeURIComponent(categoryId)}`
+    const req = prepareRequest(url, "GET", { token })
+    return await sendRequest(req)
+  }
+
+  async #createTag({
+    token,
+    organizationId,
+    categoryId,
+    name,
+    color,
+    emoji,
+    description,
+  }) {
+    const payload = {
+      organizationId,
+      categoryId,
+      name,
+    }
+    if (color !== undefined && color !== null) payload.color = color
+    if (emoji !== undefined && emoji !== null) payload.emoji = emoji
+    if (description !== undefined && description !== null)
+      payload.description = description
+
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/tags`,
+      "POST",
+      { token, ...payload }
+    )
+    return await sendRequest(req)
+  }
+
+  async #listFolders({ token, organizationId, tree, withConversationCount }) {
+    const params = []
+    if (tree) params.push("tree=true")
+    if (withConversationCount) params.push("withConversationCount=true")
+    let url = `${this.baseApiUrl}/organizations/${organizationId}/folders`
+    if (params.length > 0) {
+      url += "?" + params.join("&")
+    }
+    const req = prepareRequest(url, "GET", { token })
+    return await sendRequest(req)
+  }
+
+  async #createFolder({
+    token,
+    organizationId,
+    name,
+    parentId,
+    color,
+    emoji,
+    visibility,
+  }) {
+    const payload = { name, visibility }
+    if (parentId !== undefined && parentId !== null) payload.parentId = parentId
+    if (color !== undefined && color !== null) payload.color = color
+    if (emoji !== undefined && emoji !== null) payload.emoji = emoji
+
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/folders`,
+      "POST",
+      { token, ...payload }
+    )
+    return await sendRequest(req)
+  }
+
+  async #moveConversationToFolder({
+    token,
+    organizationId,
+    folderId,
+    conversationId,
+  }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/folders/${folderId}/conversations/${conversationId}`,
+      "POST",
+      { token }
+    )
+    return await sendRequest(req)
+  }
+
+  async #getConversation({ token, conversationId }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/conversations/${conversationId}`,
+      "GET",
+      { token }
+    )
+    return await sendRequest(req)
+  }
+
+  async #searchUsers({ token, search }) {
+    const url = `${this.baseApiUrl}/users/search?search=${encodeURIComponent(search)}`
+    const req = prepareRequest(url, "GET", { token })
+    return await sendRequest(req)
+  }
+
+  async #updateConversation({ token, conversationId, data }) {
+    const url = `${this.baseApiUrl}/conversations/${conversationId}`
+    const requestObj = new Request(url, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: token ? `Bearer ${token}` : null,
+      },
+      body: JSON.stringify(data ?? {}),
+    })
+    return await sendRequest(requestObj)
   }
 }
 

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -48,6 +48,33 @@ export class StudioApiService {
     )(args)
   }
 
+  // -- LLM / Summary methods --
+
+  async fetchLlmServices(args) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#fetchLlmServices.bind(this))
+    )(args)
+  }
+
+  async triggerSummary({ conversationId, format, flavor } = {}) {
+    return await this.#withToken(this.#triggerSummary)({
+      conversationId,
+      format,
+      flavor,
+    })
+  }
+
+  async getExportList({ conversationId } = {}) {
+    return await this.#withToken(this.#getExportList)({ conversationId })
+  }
+
+  async getExportContent({ conversationId, jobId } = {}) {
+    return await this.#withToken(this.#getExportContent)({
+      conversationId,
+      jobId,
+    })
+  }
+
   async login({ email, password }) {
     const req = prepareRequest(`${this.baseAuthUrl}/login`, "POST", {
       email,
@@ -182,6 +209,45 @@ export class StudioApiService {
       formData
     )
 
+    return await sendRequest(req)
+  }
+
+  // -- LLM / Summary private implementations --
+
+  async #fetchLlmServices({ token, organizationId }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/services/${organizationId}/llm`,
+      "GET",
+      { token }
+    )
+
+    return await sendRequest(req)
+  }
+
+  async #triggerSummary({ token, conversationId, format, flavor }) {
+    let url = `${this.baseApiUrl}/conversations/${conversationId}/download?format=${encodeURIComponent(format)}`
+    if (flavor) {
+      url += `&flavor=${encodeURIComponent(flavor)}`
+    }
+    const req = prepareRequest(url, "POST", { token })
+    return await sendRequest(req)
+  }
+
+  async #getExportList({ token, conversationId }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/conversations/${conversationId}/export/list`,
+      "GET",
+      { token }
+    )
+    return await sendRequest(req)
+  }
+
+  async #getExportContent({ token, conversationId, jobId }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/conversations/${conversationId}/export/${jobId}/content`,
+      "GET",
+      { token }
+    )
     return await sendRequest(req)
   }
 }

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -527,33 +527,25 @@ export class StudioApiService {
   }
 
   async #updateConversation({ token, conversationId, data }) {
-    const url = `${this.baseApiUrl}/conversations/${conversationId}`
-    const requestObj = new Request(url, {
-      method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: token ? `Bearer ${token}` : null,
-      },
-      body: JSON.stringify(data ?? {}),
-    })
-    return await sendRequest(requestObj)
+    const req = prepareRequest(
+      `${this.baseApiUrl}/conversations/${conversationId}`,
+      "PATCH",
+      { token, ...(data ?? {}) }
+    )
+    return await sendRequest(req)
   }
 
   async #shareConversation({ token, conversationId, email, right, notify }) {
-    const url = `${this.baseApiUrl}/conversations/${conversationId}/invite`
     const payload = { email, right }
     if (notify === false) {
       payload.notify = false
     }
-    const requestObj = new Request(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: token ? `Bearer ${token}` : null,
-      },
-      body: JSON.stringify(payload),
-    })
-    return await sendRequest(requestObj)
+    const req = prepareRequest(
+      `${this.baseApiUrl}/conversations/${conversationId}/invite`,
+      "POST",
+      { token, ...payload }
+    )
+    return await sendRequest(req)
   }
 }
 

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -134,6 +134,20 @@ export class StudioApiService {
     })
   }
 
+  async shareConversation({
+    conversationId,
+    email,
+    right = 1,
+    notify = true,
+  } = {}) {
+    return await this.#withToken(this.#shareConversation)({
+      conversationId,
+      email,
+      right,
+      notify,
+    })
+  }
+
   async login({ email, password }) {
     const req = prepareRequest(`${this.baseAuthUrl}/login`, "POST", {
       email,
@@ -426,6 +440,23 @@ export class StudioApiService {
         Authorization: token ? `Bearer ${token}` : null,
       },
       body: JSON.stringify(data ?? {}),
+    })
+    return await sendRequest(requestObj)
+  }
+
+  async #shareConversation({ token, conversationId, email, right, notify }) {
+    const url = `${this.baseApiUrl}/conversations/${conversationId}/invite`
+    const payload = { email, right }
+    if (notify === false) {
+      payload.notify = false
+    }
+    const requestObj = new Request(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: token ? `Bearer ${token}` : null,
+      },
+      body: JSON.stringify(payload),
     })
     return await sendRequest(requestObj)
   }

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -6,6 +6,12 @@ import {
 
 import mediaFactory from "../models/media.js"
 
+/**
+ * Low-level HTTP client for the LinTO Studio API.
+ *
+ * Used internally by {@link LinTO}; prefer the high-level wrapper unless you
+ * need direct access to an endpoint.
+ */
 export class StudioApiService {
   constructor({ baseUrl = "https://studio.linto.ai", token = null }) {
     this.baseApiUrl = baseUrl + "/api"

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -5,6 +5,7 @@ import {
 } from "../request.js"
 
 import mediaFactory from "../models/media.js"
+import { pickKwarg } from "../tools/pickKwarg.js"
 
 /**
  * Low-level HTTP client for the LinTO Studio API.
@@ -251,16 +252,10 @@ export class StudioApiService {
 
       // Accept both camelCase (JS convention) and snake_case (Python parity)
       // so a caller passing enable_diarization is not silently ignored.
-      const pick = (...keys) => {
-        for (const key of keys) {
-          if (args[key] !== undefined) return args[key]
-        }
-        return undefined
-      }
       const serviceConfig = generateServiceConfig(selectedService, {
-        enablePunctuation: pick("enablePunctuation", "enable_punctuation"),
-        enableDiarization: pick("enableDiarization", "enable_diarization"),
-        numberOfSpeaker: pick("numberOfSpeaker", "number_of_speaker"),
+        enablePunctuation: pickKwarg(args, "enablePunctuation", "enable_punctuation"),
+        enableDiarization: pickKwarg(args, "enableDiarization", "enable_diarization"),
+        numberOfSpeaker: pickKwarg(args, "numberOfSpeaker", "number_of_speaker"),
       })
 
       args["serviceName"] = args["serviceName"] ?? serviceConfig.serviceName

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -312,6 +312,7 @@ export class StudioApiService {
     endpoint,
     lang,
     segmentCharSize,
+    membersRight,
   }) {
     if (!file) {
       throw new Error("File is required")
@@ -325,6 +326,9 @@ export class StudioApiService {
     formData.append("segmentCharSize", segmentCharSize)
     formData.append("lang", lang)
     formData.append("endpoint", endpoint)
+    if (membersRight != null) {
+      formData.append("membersRight", String(parseInt(membersRight, 10)))
+    }
     const req = prepareMultipartFormData(
       `${this.baseApiUrl}/organizations/${organizationId}/conversations/create`,
       token,

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -249,10 +249,18 @@ export class StudioApiService {
         throw new Error(`No ASR services available for lang=${lang}`)
       }
 
+      // Accept both camelCase (JS convention) and snake_case (Python parity)
+      // so a caller passing enable_diarization is not silently ignored.
+      const pick = (...keys) => {
+        for (const key of keys) {
+          if (args[key] !== undefined) return args[key]
+        }
+        return undefined
+      }
       const serviceConfig = generateServiceConfig(selectedService, {
-        enablePunctuation: args["enablePunctuation"],
-        enableDiarization: args["enableDiarization"],
-        numberOfSpeaker: args["numberOfSpeaker"],
+        enablePunctuation: pick("enablePunctuation", "enable_punctuation"),
+        enableDiarization: pick("enableDiarization", "enable_diarization"),
+        numberOfSpeaker: pick("numberOfSpeaker", "number_of_speaker"),
       })
 
       args["serviceName"] = args["serviceName"] ?? serviceConfig.serviceName
@@ -555,7 +563,7 @@ function getServiceByQualityAndLang(services, quality, lang) {
   })
 }
 
-function generateServiceConfig(
+export function generateServiceConfig(
   service,
   {
     enablePunctuation = false,
@@ -567,17 +575,30 @@ function generateServiceConfig(
   const isWhisper = service?.model_type === "whisper"
   const subServices = service?.sub_services
 
-  const punctuationServiceList = subServices?.punctuation
+  const punctuationServiceList = subServices?.punctuation ?? []
   const punctuationService =
     enablePunctuation && !isWhisper && punctuationServiceList.length > 0
       ? punctuationServiceList[0].service_name
       : null
 
-  const diarizationServiceList = subServices?.diarization
+  const diarizationServiceList = subServices?.diarization ?? []
   const diarizationService =
     enableDiarization && diarizationServiceList.length > 0
       ? diarizationServiceList[0].service_name
       : null
+
+  // Diarization is only effectively enabled when a worker is actually
+  // available. When the caller asks for it but the selected ASR service
+  // exposes no diarization sub-service, fall back gracefully instead of
+  // sending enableDiarization=true with serviceName=null, which silently
+  // hangs the transcription on the gateway side.
+  const diarizationEffective = Boolean(enableDiarization && diarizationService)
+
+  // numberOfSpeaker may arrive as a string from env-style configuration.
+  const numberOfSpeakerInt = Number.parseInt(numberOfSpeaker, 10)
+  const numberOfSpeakerSafe = Number.isFinite(numberOfSpeakerInt)
+    ? numberOfSpeakerInt
+    : 0
 
   return {
     serviceName: service.serviceName,
@@ -590,12 +611,12 @@ function generateServiceConfig(
         serviceName: punctuationService,
       },
       diarizationConfig: {
-        enableDiarization: enableDiarization,
+        enableDiarization: diarizationEffective,
         numberOfSpeaker:
-          enableDiarization && numberOfSpeaker > 0
-            ? parseInt(numberOfSpeaker)
+          diarizationEffective && numberOfSpeakerSafe > 0
+            ? numberOfSpeakerSafe
             : null,
-        maxNumberOfSpeaker: enableDiarization ? 100 : null,
+        maxNumberOfSpeaker: diarizationEffective ? 100 : null,
         serviceName: diarizationService,
       },
       enableNormalization: true,

--- a/studio-sdk/javascript/src/services/summaryPollingService.js
+++ b/studio-sdk/javascript/src/services/summaryPollingService.js
@@ -1,3 +1,9 @@
+/**
+ * Polls an LLM summary export until it finishes.
+ *
+ * Emits `update`, `done` (with `{ content, jobId }`), `error`, and `cancelled`.
+ * Call `.stop()` to clear the underlying interval.
+ */
 export class SummaryPollingService extends EventTarget {
   #intervalId = null
 

--- a/studio-sdk/javascript/src/services/summaryPollingService.js
+++ b/studio-sdk/javascript/src/services/summaryPollingService.js
@@ -1,0 +1,73 @@
+export class SummaryPollingService extends EventTarget {
+  #intervalId = null
+
+  constructor(
+    conversationId,
+    serviceRoute,
+    apiService,
+    { intervalMs = 2000 } = {}
+  ) {
+    super()
+    this.conversationId = conversationId
+    this.serviceRoute = serviceRoute
+    this.apiService = apiService
+
+    this.#intervalId = setInterval(async () => {
+      try {
+        const exports = await this.apiService.getExportList({
+          conversationId,
+        })
+
+        const list = Array.isArray(exports) ? exports : []
+        const exportEntry = list.find((e) => e?.format === serviceRoute)
+
+        if (!exportEntry) {
+          // No matching export yet; wait for next tick.
+          return
+        }
+
+        const status = exportEntry.status
+
+        if (status === "complete" || status === "done") {
+          const jobId = exportEntry.jobId ?? null
+          let content
+          if (jobId) {
+            content = await this.apiService.getExportContent({
+              conversationId,
+              jobId,
+            })
+          } else {
+            content = exportEntry
+          }
+          this.#clearInterval()
+          this.dispatchEvent(
+            new CustomEvent("done", { detail: { content, jobId } })
+          )
+        } else if (status === "error") {
+          this.#clearInterval()
+          this.dispatchEvent(new CustomEvent("error", { detail: exportEntry }))
+        } else {
+          this.dispatchEvent(new CustomEvent("update", { detail: exportEntry }))
+        }
+      } catch (err) {
+        this.#clearInterval()
+        this.dispatchEvent(new CustomEvent("error", { detail: err }))
+      }
+    }, intervalMs)
+  }
+
+  stop() {
+    if (this.#intervalId === null) {
+      return
+    }
+    this.#clearInterval()
+    this.dispatchEvent(new CustomEvent("cancelled"))
+  }
+
+  #clearInterval() {
+    if (this.#intervalId !== null) {
+      clearInterval(this.#intervalId)
+      this.#intervalId = null
+    }
+  }
+}

--- a/studio-sdk/javascript/src/tools/equalsIgnoreCase.js
+++ b/studio-sdk/javascript/src/tools/equalsIgnoreCase.js
@@ -1,0 +1,3 @@
+export function equalsIgnoreCase(a, b) {
+  return String(a ?? "").toLowerCase() === String(b ?? "").toLowerCase()
+}

--- a/studio-sdk/javascript/src/tools/getId.js
+++ b/studio-sdk/javascript/src/tools/getId.js
@@ -1,0 +1,3 @@
+export function getId(entity) {
+  return String(entity?._id ?? entity?.id ?? "")
+}

--- a/studio-sdk/javascript/src/tools/pickKwarg.js
+++ b/studio-sdk/javascript/src/tools/pickKwarg.js
@@ -1,0 +1,6 @@
+export function pickKwarg(args, ...keys) {
+  for (const key of keys) {
+    if (args?.[key] !== undefined) return args[key]
+  }
+  return undefined
+}

--- a/studio-sdk/javascript/test/diarization.test.js
+++ b/studio-sdk/javascript/test/diarization.test.js
@@ -1,0 +1,250 @@
+/**
+ * @jest-environment node
+ *
+ * Regression tests for diarization payload construction in the JS SDK.
+ * Mirrors the Python SDK's test_upload_config.py::TestDiarizationPropagation
+ * and TestDiarizationGracefulFallback for parity.
+ */
+import { jest } from "@jest/globals"
+import { generateServiceConfig } from "../src/services/studioApiService.js"
+
+const serviceWithDiarization = () => ({
+  serviceName: "stt-fr",
+  language: "*",
+  scope: ["stt"],
+  endpoints: [{ endpoint: "/stt-fr" }],
+  model_type: "whisper",
+  sub_services: {
+    diarization: [{ service_name: "stt-diarization" }],
+    punctuation: [],
+  },
+})
+
+const serviceWithoutDiarization = () => ({
+  serviceName: "stt-fr",
+  language: "*",
+  scope: ["stt"],
+  endpoints: [{ endpoint: "/stt-fr" }],
+  model_type: "whisper",
+  sub_services: { diarization: [], punctuation: [] },
+})
+
+describe("generateServiceConfig — diarization payload", () => {
+  test("enableDiarization=true with worker → enableDiarization stays true and serviceName is set", () => {
+    const config = generateServiceConfig(serviceWithDiarization(), {
+      enableDiarization: true,
+    })
+    expect(config.config.diarizationConfig.enableDiarization).toBe(true)
+    expect(config.config.diarizationConfig.serviceName).toBe("stt-diarization")
+  })
+
+  test("enableDiarization defaults to false and serviceName is null", () => {
+    const config = generateServiceConfig(serviceWithDiarization(), {})
+    expect(config.config.diarizationConfig.enableDiarization).toBe(false)
+    expect(config.config.diarizationConfig.serviceName).toBeNull()
+    expect(config.config.diarizationConfig.numberOfSpeaker).toBeNull()
+    expect(config.config.diarizationConfig.maxNumberOfSpeaker).toBeNull()
+  })
+
+  test("numberOfSpeaker propagated as int when diarization enabled", () => {
+    const config = generateServiceConfig(serviceWithDiarization(), {
+      enableDiarization: true,
+      numberOfSpeaker: 3,
+    })
+    expect(config.config.diarizationConfig.numberOfSpeaker).toBe(3)
+  })
+
+  test("numberOfSpeaker accepts stringified values (env-style config)", () => {
+    const config = generateServiceConfig(serviceWithDiarization(), {
+      enableDiarization: true,
+      numberOfSpeaker: "3",
+    })
+    expect(config.config.diarizationConfig.numberOfSpeaker).toBe(3)
+  })
+
+  test("numberOfSpeaker=0 (or '0') results in null", () => {
+    const config = generateServiceConfig(serviceWithDiarization(), {
+      enableDiarization: true,
+      numberOfSpeaker: "0",
+    })
+    expect(config.config.diarizationConfig.numberOfSpeaker).toBeNull()
+  })
+})
+
+describe("generateServiceConfig — graceful fallback", () => {
+  test("requesting diarization without a worker falls back to disabled", () => {
+    const config = generateServiceConfig(serviceWithoutDiarization(), {
+      enableDiarization: true,
+      numberOfSpeaker: 2,
+    })
+    const diar = config.config.diarizationConfig
+    expect(diar.enableDiarization).toBe(false)
+    expect(diar.serviceName).toBeNull()
+    expect(diar.numberOfSpeaker).toBeNull()
+    expect(diar.maxNumberOfSpeaker).toBeNull()
+  })
+
+  test("missing sub_services entirely is handled (no throw)", () => {
+    const service = {
+      serviceName: "stt-fr",
+      language: "fr-FR",
+      scope: ["stt"],
+      endpoints: [{ endpoint: "/stt-fr" }],
+      model_type: "whisper",
+      // no sub_services
+    }
+    expect(() =>
+      generateServiceConfig(service, { enableDiarization: true })
+    ).not.toThrow()
+    const config = generateServiceConfig(service, { enableDiarization: true })
+    expect(config.config.diarizationConfig.enableDiarization).toBe(false)
+  })
+
+  test("requesting diarization with a worker keeps it on (sanity)", () => {
+    const config = generateServiceConfig(serviceWithDiarization(), {
+      enableDiarization: true,
+    })
+    expect(config.config.diarizationConfig.enableDiarization).toBe(true)
+    expect(config.config.diarizationConfig.serviceName).toBe("stt-diarization")
+  })
+})
+
+describe("transcribe — diarization end-to-end via fetch mock", () => {
+  let LinTO
+  let originalFetch
+
+  beforeAll(async () => {
+    LinTO = (await import("../index.js")).default
+  })
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.clearAllMocks()
+  })
+
+  function makeFetchMock(serviceList) {
+    const captured = []
+    const mock = jest.fn(async (req) => {
+      const entry = {
+        url: req.url,
+        method: req.method,
+        body: null,
+        formFields: {},
+      }
+      if (req.body) {
+        const ct = req.headers.get("content-type") || ""
+        if (ct.includes("multipart/form-data")) {
+          const fd = await req.clone().formData()
+          for (const [k, v] of fd.entries()) {
+            entry.formFields[k] = typeof v === "string" ? v : "<blob>"
+          }
+        } else {
+          entry.body = await req.clone().text()
+        }
+      }
+      captured.push(entry)
+
+      const path = new URL(req.url).pathname
+      if (path.endsWith("/api/services")) {
+        return new Response(JSON.stringify(serviceList), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      if (path.endsWith("/api/organizations")) {
+        return new Response(JSON.stringify([{ _id: "org-1" }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      if (path.includes("/conversations/create")) {
+        return new Response(JSON.stringify({ conversationId: "conv-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+    return { mock, captured }
+  }
+
+  test("enableDiarization=true is propagated end-to-end when worker is available", async () => {
+    const { mock, captured } = makeFetchMock([serviceWithDiarization()])
+    global.fetch = mock
+
+    const linto = new LinTO({
+      authToken: "tok-1",
+      baseUrl: "http://example.test",
+    })
+    const poller = await linto.transcribe(new Blob([new Uint8Array([1])]), {
+      language: "fr",
+      enableDiarization: true,
+    })
+    poller.stop()
+
+    const upload = captured.find((c) =>
+      /\/conversations\/create/.test(c.url)
+    )
+    expect(upload).toBeDefined()
+    const config = JSON.parse(upload.formFields.transcriptionConfig)
+    expect(config.diarizationConfig.enableDiarization).toBe(true)
+    expect(config.diarizationConfig.serviceName).toBe("stt-diarization")
+  })
+
+  test("enableDiarization=true with no worker available falls back gracefully", async () => {
+    const { mock, captured } = makeFetchMock([serviceWithoutDiarization()])
+    global.fetch = mock
+
+    const linto = new LinTO({
+      authToken: "tok-1",
+      baseUrl: "http://example.test",
+    })
+    const poller = await linto.transcribe(new Blob([new Uint8Array([1])]), {
+      language: "fr",
+      enableDiarization: true,
+    })
+    poller.stop()
+
+    const upload = captured.find((c) =>
+      /\/conversations\/create/.test(c.url)
+    )
+    expect(upload).toBeDefined()
+    const config = JSON.parse(upload.formFields.transcriptionConfig)
+    expect(config.diarizationConfig.enableDiarization).toBe(false)
+    expect(config.diarizationConfig.serviceName).toBeNull()
+    expect(config.diarizationConfig.numberOfSpeaker).toBeNull()
+  })
+
+  test("snake_case enable_diarization (Python-style) is honored", async () => {
+    const { mock, captured } = makeFetchMock([serviceWithDiarization()])
+    global.fetch = mock
+
+    const linto = new LinTO({
+      authToken: "tok-1",
+      baseUrl: "http://example.test",
+    })
+    // Use the lower-level apiService.uploadFile so we can pass snake_case
+    // keys that mimic a Python-style caller. The decorator must accept both.
+    await linto.apiService.uploadFile({
+      file: new Blob([new Uint8Array([1])]),
+      lang: "fr",
+      enable_diarization: true,
+      number_of_speaker: "2",
+    })
+
+    const upload = captured.find((c) =>
+      /\/conversations\/create/.test(c.url)
+    )
+    expect(upload).toBeDefined()
+    const config = JSON.parse(upload.formFields.transcriptionConfig)
+    expect(config.diarizationConfig.enableDiarization).toBe(true)
+    expect(config.diarizationConfig.numberOfSpeaker).toBe(2)
+  })
+})

--- a/studio-sdk/javascript/test/exports.test.js
+++ b/studio-sdk/javascript/test/exports.test.js
@@ -1,0 +1,381 @@
+/**
+ * @jest-environment node
+ */
+import { jest } from "@jest/globals"
+import LinTO from "../index.js"
+
+function makeFetchMock(handlers) {
+  const captured = []
+  const mock = jest.fn(async (req) => {
+    captured.push({
+      url: req.url,
+      method: req.method,
+      auth: req.headers.get("authorization"),
+    })
+    for (const h of handlers) {
+      if (h.match(req)) {
+        if (typeof h.respond === "function") {
+          return await h.respond(req)
+        }
+        const payload =
+          typeof h.payload === "function" ? await h.payload(req) : h.payload
+        const status = h.status ?? 200
+        return new Response(JSON.stringify(payload), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+    }
+    return new Response(JSON.stringify({ error: "unmatched", url: req.url }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    })
+  })
+  return { mock, captured }
+}
+
+function binaryResponse(bytes, contentType = "application/octet-stream") {
+  return new Response(bytes, {
+    status: 200,
+    headers: { "Content-Type": contentType },
+  })
+}
+
+describe("LinTO Exports / Download — high-level wrappers (mocked apiService)", () => {
+  let linto
+
+  beforeEach(() => {
+    linto = new LinTO({ authToken: "tok-1" })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test("getExportList() delegates to apiService.getExportList with conversationId", async () => {
+    linto.apiService.getExportList = jest.fn(async () => [
+      { _id: "job-1", state: "done" },
+    ])
+    const res = await linto.getExportList("conv-1")
+    expect(linto.apiService.getExportList).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+    })
+    expect(res).toEqual([{ _id: "job-1", state: "done" }])
+  })
+
+  test("getExportContent() delegates to apiService.getExportContent with conversationId and jobId", async () => {
+    linto.apiService.getExportContent = jest.fn(async () => ({ text: "hi" }))
+    const res = await linto.getExportContent("conv-1", "job-1")
+    expect(linto.apiService.getExportContent).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      jobId: "job-1",
+    })
+    expect(res).toEqual({ text: "hi" })
+  })
+
+  test("downloadConversation() defaults format to 'docx'", async () => {
+    linto.apiService.downloadConversation = jest.fn(async () => new ArrayBuffer(8))
+    await linto.downloadConversation("conv-1")
+    expect(linto.apiService.downloadConversation).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      format: "docx",
+    })
+  })
+
+  test("downloadConversation() forwards custom format", async () => {
+    linto.apiService.downloadConversation = jest.fn(async () => ({ ok: true }))
+    await linto.downloadConversation("conv-2", { format: "json" })
+    expect(linto.apiService.downloadConversation).toHaveBeenCalledWith({
+      conversationId: "conv-2",
+      format: "json",
+    })
+  })
+
+  test("getPublicationTemplates() delegates to apiService.getPublicationTemplates", async () => {
+    linto.apiService.getPublicationTemplates = jest.fn(async () => [
+      { _id: "tpl-1", name: "Default" },
+    ])
+    const res = await linto.getPublicationTemplates()
+    expect(linto.apiService.getPublicationTemplates).toHaveBeenCalledTimes(1)
+    expect(res).toEqual([{ _id: "tpl-1", name: "Default" }])
+  })
+
+  test("getTemplatePlaceholders() forwards templateId", async () => {
+    linto.apiService.getTemplatePlaceholders = jest.fn(async () => [
+      { key: "title" },
+    ])
+    const res = await linto.getTemplatePlaceholders("tpl-1")
+    expect(linto.apiService.getTemplatePlaceholders).toHaveBeenCalledWith({
+      templateId: "tpl-1",
+    })
+    expect(res).toEqual([{ key: "title" }])
+  })
+
+  test("exportWithTemplate() defaults format to 'pdf', leaves templateId/versionNumber undefined", async () => {
+    linto.apiService.exportWithTemplate = jest.fn(async () => new ArrayBuffer(4))
+    await linto.exportWithTemplate("job-1")
+    expect(linto.apiService.exportWithTemplate).toHaveBeenCalledWith({
+      jobId: "job-1",
+      format: "pdf",
+      templateId: undefined,
+      versionNumber: undefined,
+    })
+  })
+
+  test("exportWithTemplate() forwards format, templateId, versionNumber when provided", async () => {
+    linto.apiService.exportWithTemplate = jest.fn(async () => new ArrayBuffer(4))
+    await linto.exportWithTemplate("job-1", {
+      format: "docx",
+      templateId: "tpl-9",
+      versionNumber: 2,
+    })
+    expect(linto.apiService.exportWithTemplate).toHaveBeenCalledWith({
+      jobId: "job-1",
+      format: "docx",
+      templateId: "tpl-9",
+      versionNumber: 2,
+    })
+  })
+})
+
+describe("StudioApiService Exports / Download — URL/payload via mocked fetch", () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.clearAllMocks()
+  })
+
+  function makeLinto() {
+    return new LinTO({
+      authToken: "tok-1",
+      baseUrl: "https://example.test",
+    })
+  }
+
+  test("getExportList GETs /conversations/{id}/export/list and returns array", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" &&
+          /\/api\/conversations\/conv-1\/export\/list/.test(req.url),
+        payload: [{ _id: "job-1", state: "done" }],
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.getExportList("conv-1")
+    expect(res).toEqual([{ _id: "job-1", state: "done" }])
+    const call = captured.find((c) =>
+      /\/api\/conversations\/conv-1\/export\/list/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.method).toBe("GET")
+    expect(call.auth).toBe("Bearer tok-1")
+  })
+
+  test("getExportContent GETs /conversations/{id}/export/{jobId}/content", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" &&
+          /\/api\/conversations\/conv-1\/export\/job-9\/content/.test(req.url),
+        payload: { text: "the content" },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.getExportContent("conv-1", "job-9")
+    expect(res).toEqual({ text: "the content" })
+    const call = captured.find((c) =>
+      /\/api\/conversations\/conv-1\/export\/job-9\/content/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.method).toBe("GET")
+  })
+
+  test("downloadConversation POSTs /conversations/{id}/download?format=... with binary body for docx", async () => {
+    const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04]) // ZIP/docx magic
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "POST" &&
+          /\/api\/conversations\/conv-1\/download\?format=docx/.test(req.url),
+        respond: async () => binaryResponse(bytes),
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.downloadConversation("conv-1", { format: "docx" })
+    const call = captured.find((c) =>
+      /\/api\/conversations\/conv-1\/download\?format=docx/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.method).toBe("POST")
+    expect(call.auth).toBe("Bearer tok-1")
+    // In Node env we should get an ArrayBuffer back for binary formats.
+    expect(res).toBeInstanceOf(ArrayBuffer)
+    expect(new Uint8Array(res)).toEqual(bytes)
+  })
+
+  test("downloadConversation with json format returns JSON (not binary)", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "POST" &&
+          /\/api\/conversations\/conv-2\/download\?format=json/.test(req.url),
+        payload: { transcript: "hello world" },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.downloadConversation("conv-2", { format: "json" })
+    expect(res).toEqual({ transcript: "hello world" })
+    const call = captured.find((c) =>
+      /\/api\/conversations\/conv-2\/download\?format=json/.test(c.url)
+    )
+    expect(call.method).toBe("POST")
+  })
+
+  test("getPublicationTemplates GETs /publication/templates?organization_id=... and returns array", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" && /\/api\/organizations(\?|$)/.test(req.url),
+        payload: [{ _id: "org-1" }],
+      },
+      {
+        match: (req) =>
+          req.method === "GET" &&
+          /\/api\/publication\/templates\?organization_id=org-1/.test(req.url),
+        payload: [{ _id: "tpl-1", name: "Default" }],
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.getPublicationTemplates()
+    expect(res).toEqual([{ _id: "tpl-1", name: "Default" }])
+    const call = captured.find((c) =>
+      /\/api\/publication\/templates\?organization_id=org-1/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.method).toBe("GET")
+    expect(call.auth).toBe("Bearer tok-1")
+  })
+
+  test("getTemplatePlaceholders GETs /publication/templates/{templateId}/placeholders", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" &&
+          /\/api\/publication\/templates\/tpl-7\/placeholders/.test(req.url),
+        payload: [{ key: "title" }, { key: "speaker" }],
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.getTemplatePlaceholders("tpl-7")
+    expect(res).toEqual([{ key: "title" }, { key: "speaker" }])
+    const call = captured.find((c) =>
+      /\/api\/publication\/templates\/tpl-7\/placeholders/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.method).toBe("GET")
+  })
+
+  test("exportWithTemplate GETs /publication/{jobId}/export/{format} WITHOUT templateId/versionNumber when undefined", async () => {
+    const bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]) // %PDF
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" &&
+          /\/api\/publication\/job-1\/export\/pdf/.test(req.url),
+        respond: async () => binaryResponse(bytes, "application/pdf"),
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.exportWithTemplate("job-1")
+    const call = captured.find((c) =>
+      /\/api\/publication\/job-1\/export\/pdf/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.method).toBe("GET")
+    expect(call.url).not.toMatch(/templateId=/)
+    expect(call.url).not.toMatch(/versionNumber=/)
+    expect(res).toBeInstanceOf(ArrayBuffer)
+    expect(new Uint8Array(res)).toEqual(bytes)
+  })
+
+  test("exportWithTemplate includes templateId in query only when provided", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" &&
+          /\/api\/publication\/job-2\/export\/docx/.test(req.url),
+        respond: async () => binaryResponse(new Uint8Array([1, 2, 3])),
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.exportWithTemplate("job-2", {
+      format: "docx",
+      templateId: "tpl-42",
+    })
+    const call = captured.find((c) =>
+      /\/api\/publication\/job-2\/export\/docx/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.url).toMatch(/templateId=tpl-42/)
+    expect(call.url).not.toMatch(/versionNumber=/)
+  })
+
+  test("exportWithTemplate includes versionNumber in query only when provided", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" &&
+          /\/api\/publication\/job-3\/export\/pdf/.test(req.url),
+        respond: async () => binaryResponse(new Uint8Array([9])),
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.exportWithTemplate("job-3", {
+      format: "pdf",
+      templateId: "tpl-1",
+      versionNumber: 5,
+    })
+    const call = captured.find((c) =>
+      /\/api\/publication\/job-3\/export\/pdf/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.url).toMatch(/templateId=tpl-1/)
+    expect(call.url).toMatch(/versionNumber=5/)
+  })
+
+  test("exportWithTemplate propagates format into URL path", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" &&
+          /\/api\/publication\/job-4\/export\/odt/.test(req.url),
+        respond: async () => binaryResponse(new Uint8Array([7, 7])),
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.exportWithTemplate("job-4", { format: "odt" })
+    const call = captured.find((c) =>
+      /\/api\/publication\/job-4\/export\/odt/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    // Path-only (no template/version) -> no query other than the t= cache buster.
+    expect(call.url).not.toMatch(/templateId=/)
+    expect(call.url).not.toMatch(/versionNumber=/)
+  })
+})

--- a/studio-sdk/javascript/test/pollingService.test.js
+++ b/studio-sdk/javascript/test/pollingService.test.js
@@ -1,0 +1,184 @@
+import { jest } from "@jest/globals"
+import { PollingService } from "../src/services/pollingService.js"
+
+/**
+ * Helper: build a fake StudioApiService whose getMediaStatus returns the next
+ * state from a queue, and whose getMedia returns a fixed media object.
+ */
+function createFakeApiService({ statuses = [], media = { id: "media-1" } } = {}) {
+  let idx = 0
+  return {
+    getMediaStatus: jest.fn(async () => {
+      const state = idx < statuses.length ? statuses[idx] : statuses[statuses.length - 1]
+      idx += 1
+      if (state instanceof Error) {
+        throw state
+      }
+      return { jobs: { transcription: state } }
+    }),
+    getMedia: jest.fn(async () => media),
+  }
+}
+
+/**
+ * Advance fake timers and flush all microtasks pending after each tick. We
+ * cannot simply call jest.advanceTimersByTime() because the setInterval
+ * callback awaits async work; we need to let those promises settle.
+ */
+async function tick(ms = 1000, iterations = 1) {
+  for (let i = 0; i < iterations; i++) {
+    jest.advanceTimersByTime(ms)
+    // Flush pending promise jobs. A few macrotask/microtask flushes are
+    // needed because the callback chains multiple awaits.
+    for (let j = 0; j < 5; j++) {
+      await Promise.resolve()
+    }
+  }
+}
+
+describe("PollingService", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  test("emits 'update' on each tick while the job is not finished", async () => {
+    const api = createFakeApiService({
+      statuses: [
+        { state: "processing", progress: 10 },
+        { state: "processing", progress: 50 },
+        { state: "processing", progress: 80 },
+      ],
+    })
+    const poller = new PollingService("media-1", api)
+
+    const updates = []
+    poller.addEventListener("update", (e) => updates.push(e.detail))
+
+    await tick(1000, 3)
+
+    expect(api.getMediaStatus).toHaveBeenCalledTimes(3)
+    expect(updates).toHaveLength(3)
+    expect(updates[0]).toEqual({ state: "processing", progress: 10 })
+    expect(updates[2]).toEqual({ state: "processing", progress: 80 })
+
+    poller.stop()
+  })
+
+  test("emits 'done' with the media and stops polling automatically", async () => {
+    const media = { id: "media-1", fullText: "hello world" }
+    const api = createFakeApiService({
+      statuses: [{ state: "processing" }, { state: "done" }],
+      media,
+    })
+    const poller = new PollingService("media-1", api)
+
+    const doneHandler = jest.fn()
+    poller.addEventListener("done", doneHandler)
+
+    await tick(1000, 2)
+
+    expect(doneHandler).toHaveBeenCalledTimes(1)
+    expect(doneHandler.mock.calls[0][0].detail).toBe(media)
+    expect(api.getMedia).toHaveBeenCalledTimes(1)
+
+    // Calls before the done state count + the done tick itself.
+    const statusCallsAfterDone = api.getMediaStatus.mock.calls.length
+
+    // Advance further; no more polling should happen.
+    await tick(1000, 5)
+    expect(api.getMediaStatus.mock.calls.length).toBe(statusCallsAfterDone)
+  })
+
+  test("emits 'error' when job.state == 'error' and stops automatically", async () => {
+    const errorJob = { state: "error", reason: "asr failed" }
+    const api = createFakeApiService({
+      statuses: [{ state: "processing" }, errorJob],
+    })
+    const poller = new PollingService("media-1", api)
+
+    const errorHandler = jest.fn()
+    poller.addEventListener("error", errorHandler)
+
+    await tick(1000, 2)
+
+    expect(errorHandler).toHaveBeenCalledTimes(1)
+    expect(errorHandler.mock.calls[0][0].detail).toEqual(errorJob)
+
+    const callsAfterError = api.getMediaStatus.mock.calls.length
+    await tick(1000, 3)
+    expect(api.getMediaStatus.mock.calls.length).toBe(callsAfterError)
+  })
+
+  test("emits 'error' and stops if the API throws", async () => {
+    const apiError = new Error("network down")
+    const api = createFakeApiService({
+      statuses: [apiError],
+    })
+    const poller = new PollingService("media-1", api)
+
+    const errorHandler = jest.fn()
+    poller.addEventListener("error", errorHandler)
+
+    await tick(1000, 1)
+
+    expect(errorHandler).toHaveBeenCalledTimes(1)
+    expect(errorHandler.mock.calls[0][0].detail).toBe(apiError)
+
+    const callsAfterError = api.getMediaStatus.mock.calls.length
+    await tick(1000, 3)
+    expect(api.getMediaStatus.mock.calls.length).toBe(callsAfterError)
+  })
+
+  test(".stop() clears the interval and is idempotent", async () => {
+    const api = createFakeApiService({
+      statuses: [{ state: "processing" }],
+    })
+    const poller = new PollingService("media-1", api)
+
+    await tick(1000, 2)
+    const callsBeforeStop = api.getMediaStatus.mock.calls.length
+    expect(callsBeforeStop).toBeGreaterThan(0)
+
+    expect(() => poller.stop()).not.toThrow()
+    expect(() => poller.stop()).not.toThrow()
+    expect(() => poller.stop()).not.toThrow()
+
+    await tick(1000, 5)
+    expect(api.getMediaStatus.mock.calls.length).toBe(callsBeforeStop)
+  })
+
+  test(".stop() dispatches a 'cancelled' event, only once", async () => {
+    const api = createFakeApiService({
+      statuses: [{ state: "processing" }],
+    })
+    const poller = new PollingService("media-1", api)
+
+    const cancelledHandler = jest.fn()
+    poller.addEventListener("cancelled", cancelledHandler)
+
+    poller.stop()
+    poller.stop() // idempotent: should not redispatch
+
+    expect(cancelledHandler).toHaveBeenCalledTimes(1)
+  })
+
+  test("automatic stop after 'done' does NOT emit 'cancelled'", async () => {
+    const api = createFakeApiService({
+      statuses: [{ state: "done" }],
+      media: { id: "x" },
+    })
+    const poller = new PollingService("media-1", api)
+
+    const cancelledHandler = jest.fn()
+    poller.addEventListener("cancelled", cancelledHandler)
+
+    await tick(1000, 1)
+
+    expect(cancelledHandler).not.toHaveBeenCalled()
+  })
+})

--- a/studio-sdk/javascript/test/sharing.test.js
+++ b/studio-sdk/javascript/test/sharing.test.js
@@ -1,0 +1,340 @@
+/**
+ * @jest-environment node
+ */
+import { jest } from "@jest/globals"
+import LinTO from "../index.js"
+
+function makeFetchMock(handlers) {
+  const captured = []
+  const mock = jest.fn(async (req) => {
+    captured.push({
+      url: req.url,
+      method: req.method,
+      auth: req.headers.get("authorization"),
+      body: req.body ? await readBody(req) : null,
+    })
+    for (const h of handlers) {
+      if (h.match(req)) {
+        const payload =
+          typeof h.payload === "function" ? await h.payload(req) : h.payload
+        const status = h.status ?? 200
+        return new Response(JSON.stringify(payload), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+    }
+    return new Response(JSON.stringify({ error: "unmatched", url: req.url }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    })
+  })
+  return { mock, captured }
+}
+
+async function readBody(req) {
+  try {
+    return await req.clone().text()
+  } catch (_) {
+    return null
+  }
+}
+
+describe("LinTO Sharing — high-level wrappers (mocked apiService)", () => {
+  let linto
+
+  beforeEach(() => {
+    linto = new LinTO({ authToken: "tok-1" })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test("shareConversation() delegates to apiService with default right=1 and notify=true", async () => {
+    linto.apiService.shareConversation = jest.fn(async () => ({ ok: true }))
+    await linto.shareConversation("conv-1", "alice@example.com")
+    expect(linto.apiService.shareConversation).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      email: "alice@example.com",
+      right: 1,
+      notify: true,
+    })
+  })
+
+  test("shareConversation() forwards custom right and notify=false", async () => {
+    linto.apiService.shareConversation = jest.fn(async () => ({ ok: true }))
+    await linto.shareConversation("conv-1", "bob@example.com", {
+      right: 2,
+      notify: false,
+    })
+    expect(linto.apiService.shareConversation).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      email: "bob@example.com",
+      right: 2,
+      notify: false,
+    })
+  })
+
+  test("searchUsers() delegates to apiService.searchUsers", async () => {
+    linto.apiService.searchUsers = jest.fn(async () => [
+      { _id: "u1", email: "x@y.z" },
+    ])
+    const res = await linto.searchUsers("x@y.z")
+    expect(linto.apiService.searchUsers).toHaveBeenCalledWith({
+      search: "x@y.z",
+    })
+    expect(res).toEqual([{ _id: "u1", email: "x@y.z" }])
+  })
+
+  test("updateConversation() delegates to apiService.updateConversation", async () => {
+    linto.apiService.updateConversation = jest.fn(async () => ({ ok: true }))
+    await linto.updateConversation("conv-2", { owner: "u1" })
+    expect(linto.apiService.updateConversation).toHaveBeenCalledWith({
+      conversationId: "conv-2",
+      data: { owner: "u1" },
+    })
+  })
+
+  test("setConversationOwner() happy path: finds user, updates owner, clears sharedWithUsers", async () => {
+    linto.apiService.searchUsers = jest.fn(async () => [
+      { _id: "u-1", email: "alice@example.com" },
+    ])
+    linto.apiService.updateConversation = jest.fn(async () => ({ ok: true }))
+    const res = await linto.setConversationOwner("conv-1", "alice@example.com")
+    expect(res).toBe("u-1")
+    expect(linto.apiService.updateConversation).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      data: { owner: "u-1", sharedWithUsers: [] },
+    })
+  })
+
+  test("setConversationOwner() returns null when search returns no users", async () => {
+    linto.apiService.searchUsers = jest.fn(async () => [])
+    linto.apiService.updateConversation = jest.fn()
+    const res = await linto.setConversationOwner("conv-1", "ghost@example.com")
+    expect(res).toBeNull()
+    expect(linto.apiService.updateConversation).not.toHaveBeenCalled()
+  })
+
+  test("setConversationOwner() returns null when search returns null/undefined", async () => {
+    linto.apiService.searchUsers = jest.fn(async () => null)
+    linto.apiService.updateConversation = jest.fn()
+    const res = await linto.setConversationOwner("conv-1", "ghost@example.com")
+    expect(res).toBeNull()
+    expect(linto.apiService.updateConversation).not.toHaveBeenCalled()
+  })
+
+  test("setConversationOwner() matches email case-insensitively", async () => {
+    linto.apiService.searchUsers = jest.fn(async () => [
+      { _id: "u-x", email: "Alice@Example.COM" },
+    ])
+    linto.apiService.updateConversation = jest.fn(async () => ({ ok: true }))
+    const res = await linto.setConversationOwner("conv-1", "alice@example.com")
+    expect(res).toBe("u-x")
+    expect(linto.apiService.updateConversation).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      data: { owner: "u-x", sharedWithUsers: [] },
+    })
+  })
+
+  test("setConversationOwner() returns null when no result matches exactly", async () => {
+    linto.apiService.searchUsers = jest.fn(async () => [
+      { _id: "u-1", email: "bob@example.com" },
+      { _id: "u-2", email: "charlie@example.com" },
+    ])
+    linto.apiService.updateConversation = jest.fn()
+    const res = await linto.setConversationOwner("conv-1", "alice@example.com")
+    expect(res).toBeNull()
+    expect(linto.apiService.updateConversation).not.toHaveBeenCalled()
+  })
+
+  test("setConversationOwner() picks the matching user among many", async () => {
+    linto.apiService.searchUsers = jest.fn(async () => [
+      { _id: "u-1", email: "alicia@example.com" },
+      { _id: "u-2", email: "alice@example.com" },
+      { _id: "u-3", email: "alfred@example.com" },
+    ])
+    linto.apiService.updateConversation = jest.fn(async () => ({ ok: true }))
+    const res = await linto.setConversationOwner("conv-1", "alice@example.com")
+    expect(res).toBe("u-2")
+  })
+})
+
+describe("StudioApiService Sharing — URL/payload via mocked fetch", () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.clearAllMocks()
+  })
+
+  function makeLinto() {
+    return new LinTO({
+      authToken: "tok-1",
+      baseUrl: "https://example.test",
+    })
+  }
+
+  test("shareConversation POSTs /conversations/{id}/invite with email and right", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "POST" &&
+          /\/api\/conversations\/conv-1\/invite/.test(req.url),
+        payload: { ok: true },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.shareConversation("conv-1", "alice@example.com")
+    const call = captured.find(
+      (c) =>
+        c.method === "POST" && /\/conversations\/conv-1\/invite/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.auth).toBe("Bearer tok-1")
+    expect(call.url).toMatch(/\/api\/conversations\/conv-1\/invite/)
+    const body = JSON.parse(call.body)
+    expect(body).toEqual({ email: "alice@example.com", right: 1 })
+  })
+
+  test("shareConversation with notify=true (default) OMITS the notify field", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) => /\/conversations\/conv-1\/invite/.test(req.url),
+        payload: { ok: true },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.shareConversation("conv-1", "alice@example.com", { notify: true })
+    const call = captured.find((c) =>
+      /\/conversations\/conv-1\/invite/.test(c.url)
+    )
+    const body = JSON.parse(call.body)
+    expect(body).not.toHaveProperty("notify")
+    expect(body).toEqual({ email: "alice@example.com", right: 1 })
+  })
+
+  test("shareConversation with notify=false INCLUDES notify:false in payload", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) => /\/conversations\/conv-1\/invite/.test(req.url),
+        payload: { ok: true },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.shareConversation("conv-1", "alice@example.com", {
+      notify: false,
+    })
+    const call = captured.find((c) =>
+      /\/conversations\/conv-1\/invite/.test(c.url)
+    )
+    const body = JSON.parse(call.body)
+    expect(body).toEqual({
+      email: "alice@example.com",
+      right: 1,
+      notify: false,
+    })
+  })
+
+  test("shareConversation forwards custom right value", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) => /\/conversations\/conv-9\/invite/.test(req.url),
+        payload: { ok: true },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.shareConversation("conv-9", "carol@example.com", { right: 3 })
+    const call = captured.find((c) =>
+      /\/conversations\/conv-9\/invite/.test(c.url)
+    )
+    const body = JSON.parse(call.body)
+    expect(body).toEqual({ email: "carol@example.com", right: 3 })
+  })
+
+  test("searchUsers GETs /users/search?search=... with Bearer token", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" && /\/api\/users\/search/.test(req.url),
+        payload: [{ _id: "u-1", email: "alice@example.com" }],
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.searchUsers("alice@example.com")
+    expect(res).toEqual([{ _id: "u-1", email: "alice@example.com" }])
+    const call = captured.find((c) => /\/api\/users\/search/.test(c.url))
+    expect(call.method).toBe("GET")
+    expect(call.auth).toBe("Bearer tok-1")
+    expect(call.url).toMatch(/\/api\/users\/search\?search=alice%40example\.com/)
+  })
+
+  test("updateConversation PATCHes /conversations/{id} with arbitrary data (owner + sharedWithUsers)", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "PATCH" &&
+          /\/api\/conversations\/conv-5/.test(req.url),
+        payload: { ok: true },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.updateConversation("conv-5", {
+      owner: "u-1",
+      sharedWithUsers: [],
+    })
+    const call = captured.find(
+      (c) =>
+        c.method === "PATCH" && /\/api\/conversations\/conv-5/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.auth).toBe("Bearer tok-1")
+    expect(JSON.parse(call.body)).toEqual({
+      owner: "u-1",
+      sharedWithUsers: [],
+    })
+  })
+
+  test("setConversationOwner end-to-end via fetch mock (search GET + PATCH)", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" && /\/api\/users\/search/.test(req.url),
+        payload: [{ _id: "u-7", email: "Alice@Example.COM" }],
+      },
+      {
+        match: (req) =>
+          req.method === "PATCH" &&
+          /\/api\/conversations\/conv-2/.test(req.url),
+        payload: { ok: true },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const userId = await linto.setConversationOwner(
+      "conv-2",
+      "alice@example.com"
+    )
+    expect(userId).toBe("u-7")
+    const patchCall = captured.find(
+      (c) =>
+        c.method === "PATCH" && /\/api\/conversations\/conv-2/.test(c.url)
+    )
+    expect(patchCall).toBeDefined()
+    expect(JSON.parse(patchCall.body)).toEqual({
+      owner: "u-7",
+      sharedWithUsers: [],
+    })
+  })
+})

--- a/studio-sdk/javascript/test/summarize.test.js
+++ b/studio-sdk/javascript/test/summarize.test.js
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment node
+ */
+import { jest } from "@jest/globals"
+import LinTO from "../index.js"
+import { SummaryPollingService } from "../src/services/summaryPollingService.js"
+
+describe("LinTO.summarize / listLlmServices", () => {
+  let linto
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    linto = new LinTO({ authToken: "tok-1" })
+    // Stub apiService methods used by summarize() and the polling service.
+    linto.apiService.triggerSummary = jest.fn(async () => ({ ok: true }))
+    linto.apiService.getExportList = jest.fn(async () => [])
+    linto.apiService.getExportContent = jest.fn(async () => ({ text: "x" }))
+    linto.apiService.fetchLlmServices = jest.fn(async () => [
+      { route: "summary/short", name: "Short summary" },
+    ])
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  test("listLlmServices() delegates to apiService.fetchLlmServices()", async () => {
+    const services = await linto.listLlmServices()
+    expect(linto.apiService.fetchLlmServices).toHaveBeenCalledTimes(1)
+    expect(services).toEqual([
+      { route: "summary/short", name: "Short summary" },
+    ])
+  })
+
+  test("summarize() calls triggerSummary with conversationId, format, flavor=undefined by default", async () => {
+    const poller = await linto.summarize("conv-1", "summary/short")
+    expect(linto.apiService.triggerSummary).toHaveBeenCalledTimes(1)
+    expect(linto.apiService.triggerSummary).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      format: "summary/short",
+      flavor: undefined,
+    })
+    expect(poller).toBeInstanceOf(SummaryPollingService)
+    poller.stop()
+  })
+
+  test("summarize() forwards flavor to triggerSummary when provided", async () => {
+    const poller = await linto.summarize("conv-2", "summary/long", {
+      flavor: "executive",
+    })
+    expect(linto.apiService.triggerSummary).toHaveBeenCalledWith({
+      conversationId: "conv-2",
+      format: "summary/long",
+      flavor: "executive",
+    })
+    poller.stop()
+  })
+
+  test("summarize() returns a SummaryPollingService bound to the conversation+route", async () => {
+    const poller = await linto.summarize("conv-3", "summary/short")
+    expect(poller.conversationId).toBe("conv-3")
+    expect(poller.serviceRoute).toBe("summary/short")
+    expect(poller.apiService).toBe(linto.apiService)
+    poller.stop()
+  })
+})
+
+describe("StudioApiService.triggerSummary URL/payload", () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.clearAllMocks()
+  })
+
+  test("triggerSummary POSTs to /conversations/{id}/download?format=... (no flavor)", async () => {
+    const captured = []
+    global.fetch = jest.fn(async (req) => {
+      captured.push({ url: req.url, method: req.method })
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+
+    const linto = new LinTO({
+      authToken: "tok-1",
+      baseUrl: "https://example.test",
+    })
+
+    await linto.apiService.triggerSummary({
+      conversationId: "conv-1",
+      format: "summary/short",
+    })
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(captured[0].method).toBe("POST")
+    expect(captured[0].url).toMatch(
+      /\/api\/conversations\/conv-1\/download\?format=summary%2Fshort/
+    )
+    expect(captured[0].url).not.toMatch(/flavor=/)
+  })
+
+  test("triggerSummary appends &flavor=... when flavor is provided", async () => {
+    const captured = []
+    global.fetch = jest.fn(async (req) => {
+      captured.push({ url: req.url, method: req.method })
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+
+    const linto = new LinTO({
+      authToken: "tok-1",
+      baseUrl: "https://example.test",
+    })
+
+    await linto.apiService.triggerSummary({
+      conversationId: "conv-2",
+      format: "summary/long",
+      flavor: "executive",
+    })
+
+    expect(captured[0].method).toBe("POST")
+    expect(captured[0].url).toMatch(
+      /\/api\/conversations\/conv-2\/download\?format=summary%2Flong&flavor=executive/
+    )
+  })
+
+  test("fetchLlmServices GETs /services/{orgId}/llm with token", async () => {
+    const captured = []
+    global.fetch = jest.fn(async (req) => {
+      captured.push({
+        url: req.url,
+        method: req.method,
+        auth: req.headers.get("authorization"),
+      })
+      // First call to /organizations returns an org list, subsequent return services.
+      if (req.url.includes("/organizations") && !req.url.includes("/services/")) {
+        return new Response(JSON.stringify([{ _id: "org-1" }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      return new Response(JSON.stringify([{ route: "summary/short" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+
+    const linto = new LinTO({
+      authToken: "tok-1",
+      baseUrl: "https://example.test",
+    })
+
+    const services = await linto.listLlmServices()
+
+    expect(services).toEqual([{ route: "summary/short" }])
+    const llmCall = captured.find((c) => c.url.includes("/services/org-1/llm"))
+    expect(llmCall).toBeDefined()
+    expect(llmCall.method).toBe("GET")
+    expect(llmCall.auth).toBe("Bearer tok-1")
+  })
+})

--- a/studio-sdk/javascript/test/summaryPollingService.test.js
+++ b/studio-sdk/javascript/test/summaryPollingService.test.js
@@ -1,0 +1,294 @@
+import { jest } from "@jest/globals"
+import { SummaryPollingService } from "../src/services/summaryPollingService.js"
+
+/**
+ * Helper: build a fake StudioApiService whose getExportList returns the next
+ * payload from a queue, and whose getExportContent returns a fixed content.
+ */
+function createFakeApiService({
+  exportsQueue = [],
+  content = { text: "summary content" },
+} = {}) {
+  let idx = 0
+  return {
+    getExportList: jest.fn(async () => {
+      const payload =
+        idx < exportsQueue.length
+          ? exportsQueue[idx]
+          : exportsQueue[exportsQueue.length - 1]
+      idx += 1
+      if (payload instanceof Error) {
+        throw payload
+      }
+      return payload
+    }),
+    getExportContent: jest.fn(async () => content),
+  }
+}
+
+/**
+ * Advance fake timers and flush microtasks so async callbacks settle.
+ */
+async function tick(ms = 2000, iterations = 1) {
+  for (let i = 0; i < iterations; i++) {
+    jest.advanceTimersByTime(ms)
+    for (let j = 0; j < 10; j++) {
+      await Promise.resolve()
+    }
+  }
+}
+
+describe("SummaryPollingService", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.clearAllMocks()
+  })
+
+  test("emits 'update' on each tick while the matching export is not finished", async () => {
+    const api = createFakeApiService({
+      exportsQueue: [
+        [{ format: "summary/short", status: "processing", progress: 10 }],
+        [{ format: "summary/short", status: "processing", progress: 60 }],
+        [{ format: "summary/short", status: "processing", progress: 90 }],
+      ],
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const updates = []
+    poller.addEventListener("update", (e) => updates.push(e.detail))
+
+    await tick(2000, 3)
+
+    expect(api.getExportList).toHaveBeenCalledTimes(3)
+    expect(api.getExportList).toHaveBeenCalledWith({ conversationId: "conv-1" })
+    expect(updates).toHaveLength(3)
+    expect(updates[0].progress).toBe(10)
+    expect(updates[2].progress).toBe(90)
+
+    poller.stop()
+  })
+
+  test("waits when no matching export is present yet (no emit)", async () => {
+    const api = createFakeApiService({
+      exportsQueue: [[], [{ format: "other", status: "processing" }]],
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const updateHandler = jest.fn()
+    const doneHandler = jest.fn()
+    const errorHandler = jest.fn()
+    poller.addEventListener("update", updateHandler)
+    poller.addEventListener("done", doneHandler)
+    poller.addEventListener("error", errorHandler)
+
+    await tick(2000, 2)
+
+    expect(updateHandler).not.toHaveBeenCalled()
+    expect(doneHandler).not.toHaveBeenCalled()
+    expect(errorHandler).not.toHaveBeenCalled()
+    poller.stop()
+  })
+
+  test("emits 'done' with {content, jobId} when status is 'complete' and auto-stops", async () => {
+    const api = createFakeApiService({
+      exportsQueue: [
+        [{ format: "summary/short", status: "processing" }],
+        [
+          {
+            format: "summary/short",
+            status: "complete",
+            jobId: "job-42",
+          },
+        ],
+      ],
+      content: { text: "final summary" },
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const doneHandler = jest.fn()
+    poller.addEventListener("done", doneHandler)
+
+    await tick(2000, 2)
+
+    expect(doneHandler).toHaveBeenCalledTimes(1)
+    expect(doneHandler.mock.calls[0][0].detail).toEqual({
+      content: { text: "final summary" },
+      jobId: "job-42",
+    })
+    expect(api.getExportContent).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      jobId: "job-42",
+    })
+
+    const callsAfterDone = api.getExportList.mock.calls.length
+    await tick(2000, 4)
+    expect(api.getExportList.mock.calls.length).toBe(callsAfterDone)
+  })
+
+  test("emits 'done' with status 'done' as well (Python parity)", async () => {
+    const api = createFakeApiService({
+      exportsQueue: [
+        [{ format: "summary/short", status: "done", jobId: "job-7" }],
+      ],
+      content: "raw content",
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const doneHandler = jest.fn()
+    poller.addEventListener("done", doneHandler)
+
+    await tick(2000, 1)
+
+    expect(doneHandler).toHaveBeenCalledTimes(1)
+    expect(doneHandler.mock.calls[0][0].detail.jobId).toBe("job-7")
+    expect(doneHandler.mock.calls[0][0].detail.content).toBe("raw content")
+  })
+
+  test("emits 'done' with jobId=null and content=export when no jobId", async () => {
+    const exportEntry = { format: "summary/short", status: "complete" }
+    const api = createFakeApiService({
+      exportsQueue: [[exportEntry]],
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const doneHandler = jest.fn()
+    poller.addEventListener("done", doneHandler)
+
+    await tick(2000, 1)
+
+    expect(doneHandler).toHaveBeenCalledTimes(1)
+    expect(doneHandler.mock.calls[0][0].detail).toEqual({
+      content: exportEntry,
+      jobId: null,
+    })
+    expect(api.getExportContent).not.toHaveBeenCalled()
+  })
+
+  test("emits 'error' when status is 'error' and stops automatically", async () => {
+    const errExport = {
+      format: "summary/short",
+      status: "error",
+      reason: "llm failed",
+    }
+    const api = createFakeApiService({
+      exportsQueue: [[errExport]],
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const errorHandler = jest.fn()
+    poller.addEventListener("error", errorHandler)
+
+    await tick(2000, 1)
+
+    expect(errorHandler).toHaveBeenCalledTimes(1)
+    expect(errorHandler.mock.calls[0][0].detail).toEqual(errExport)
+
+    const callsAfterError = api.getExportList.mock.calls.length
+    await tick(2000, 3)
+    expect(api.getExportList.mock.calls.length).toBe(callsAfterError)
+  })
+
+  test("emits 'error' and stops if the API throws", async () => {
+    const apiError = new Error("network down")
+    const api = createFakeApiService({ exportsQueue: [apiError] })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const errorHandler = jest.fn()
+    poller.addEventListener("error", errorHandler)
+
+    await tick(2000, 1)
+
+    expect(errorHandler).toHaveBeenCalledTimes(1)
+    expect(errorHandler.mock.calls[0][0].detail).toBe(apiError)
+
+    const callsAfterError = api.getExportList.mock.calls.length
+    await tick(2000, 3)
+    expect(api.getExportList.mock.calls.length).toBe(callsAfterError)
+  })
+
+  test(".stop() clears the interval and is idempotent", async () => {
+    const api = createFakeApiService({
+      exportsQueue: [[{ format: "summary/short", status: "processing" }]],
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+
+    await tick(2000, 2)
+    const callsBeforeStop = api.getExportList.mock.calls.length
+    expect(callsBeforeStop).toBeGreaterThan(0)
+
+    expect(() => poller.stop()).not.toThrow()
+    expect(() => poller.stop()).not.toThrow()
+    expect(() => poller.stop()).not.toThrow()
+
+    await tick(2000, 5)
+    expect(api.getExportList.mock.calls.length).toBe(callsBeforeStop)
+  })
+
+  test(".stop() dispatches 'cancelled' once and only once", async () => {
+    const api = createFakeApiService({
+      exportsQueue: [[{ format: "summary/short", status: "processing" }]],
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const cancelledHandler = jest.fn()
+    poller.addEventListener("cancelled", cancelledHandler)
+
+    poller.stop()
+    poller.stop()
+    poller.stop()
+
+    expect(cancelledHandler).toHaveBeenCalledTimes(1)
+  })
+
+  test("auto-stop after 'done' does NOT emit 'cancelled'", async () => {
+    const api = createFakeApiService({
+      exportsQueue: [
+        [{ format: "summary/short", status: "complete", jobId: "j" }],
+      ],
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const cancelledHandler = jest.fn()
+    poller.addEventListener("cancelled", cancelledHandler)
+
+    await tick(2000, 1)
+
+    expect(cancelledHandler).not.toHaveBeenCalled()
+  })
+
+  test("filters exports by serviceRoute (format field)", async () => {
+    const target = {
+      format: "summary/short",
+      status: "complete",
+      jobId: "job-z",
+    }
+    const api = createFakeApiService({
+      exportsQueue: [
+        [
+          { format: "summary/long", status: "complete", jobId: "other-job" },
+          { format: "docx", status: "complete", jobId: "docx-job" },
+          target,
+        ],
+      ],
+      content: "right content",
+    })
+
+    const poller = new SummaryPollingService("conv-1", "summary/short", api)
+    const doneHandler = jest.fn()
+    poller.addEventListener("done", doneHandler)
+
+    await tick(2000, 1)
+
+    expect(doneHandler).toHaveBeenCalledTimes(1)
+    expect(doneHandler.mock.calls[0][0].detail.jobId).toBe("job-z")
+    expect(api.getExportContent).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      jobId: "job-z",
+    })
+  })
+})

--- a/studio-sdk/javascript/test/taxonomy.test.js
+++ b/studio-sdk/javascript/test/taxonomy.test.js
@@ -1,0 +1,536 @@
+/**
+ * @jest-environment node
+ */
+import { jest } from "@jest/globals"
+import LinTO from "../index.js"
+
+/**
+ * Build a mock fetch that captures every Request and resolves payloads
+ * based on a URL/method matcher list. The first matching handler wins.
+ */
+function makeFetchMock(handlers) {
+  const captured = []
+  const mock = jest.fn(async (req) => {
+    captured.push({
+      url: req.url,
+      method: req.method,
+      auth: req.headers.get("authorization"),
+      body: req.body ? await readBody(req) : null,
+    })
+    for (const h of handlers) {
+      if (h.match(req)) {
+        const payload =
+          typeof h.payload === "function" ? await h.payload(req) : h.payload
+        const status = h.status ?? 200
+        return new Response(JSON.stringify(payload), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+    }
+    return new Response(JSON.stringify({ error: "unmatched", url: req.url }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    })
+  })
+  return { mock, captured }
+}
+
+async function readBody(req) {
+  try {
+    return await req.clone().text()
+  } catch (_) {
+    return null
+  }
+}
+
+describe("LinTO Taxonomy — high-level wrappers (mocked apiService)", () => {
+  let linto
+
+  beforeEach(() => {
+    linto = new LinTO({ authToken: "tok-1" })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test("listCategories() delegates to apiService.listCategories()", async () => {
+    linto.apiService.listCategories = jest.fn(async () => [
+      { _id: "c1", name: "Tags" },
+    ])
+    const res = await linto.listCategories()
+    expect(linto.apiService.listCategories).toHaveBeenCalledTimes(1)
+    expect(res).toEqual([{ _id: "c1", name: "Tags" }])
+  })
+
+  test("listTags(categoryId) forwards { categoryId } to apiService", async () => {
+    linto.apiService.listTags = jest.fn(async () => [
+      { _id: "t1", name: "important" },
+    ])
+    const res = await linto.listTags("c1")
+    expect(linto.apiService.listTags).toHaveBeenCalledWith({ categoryId: "c1" })
+    expect(res).toEqual([{ _id: "t1", name: "important" }])
+  })
+
+  test("createTag(categoryId, name, opts) forwards full payload", async () => {
+    linto.apiService.createTag = jest.fn(async () => ({
+      _id: "t9",
+      name: "n",
+    }))
+    const res = await linto.createTag("c1", "n", { color: "red", emoji: "*" })
+    expect(linto.apiService.createTag).toHaveBeenCalledWith({
+      categoryId: "c1",
+      name: "n",
+      color: "red",
+      emoji: "*",
+    })
+    expect(res._id).toBe("t9")
+  })
+
+  test("ensureTag() returns existing tag id (case-insensitive)", async () => {
+    linto.apiService.listCategories = jest.fn(async () => [
+      { _id: "c1", name: "Tags" },
+    ])
+    linto.apiService.listTags = jest.fn(async () => [
+      { _id: "t-abc", name: "ImPoRtAnT" },
+    ])
+    linto.apiService.createTag = jest.fn()
+    const id = await linto.ensureTag("important")
+    expect(id).toBe("t-abc")
+    expect(linto.apiService.createTag).not.toHaveBeenCalled()
+  })
+
+  test("ensureTag() creates tag if absent and returns its id", async () => {
+    linto.apiService.listCategories = jest.fn(async () => [
+      { _id: "c1", name: "tags" },
+    ])
+    linto.apiService.listTags = jest.fn(async () => [])
+    linto.apiService.createTag = jest.fn(async () => ({
+      _id: "t-new",
+      name: "new",
+    }))
+    const id = await linto.ensureTag("new", { color: "blue" })
+    expect(id).toBe("t-new")
+    expect(linto.apiService.createTag).toHaveBeenCalledWith({
+      categoryId: "c1",
+      name: "new",
+      color: "blue",
+      emoji: undefined,
+    })
+  })
+
+  test("ensureTag() falls back to first category when categoryName not found", async () => {
+    linto.apiService.listCategories = jest.fn(async () => [
+      { _id: "c-first", name: "Other" },
+      { _id: "c-second", name: "Else" },
+    ])
+    linto.apiService.listTags = jest.fn(async () => [])
+    linto.apiService.createTag = jest.fn(async (args) => ({
+      _id: "t-created",
+      name: args.name,
+    }))
+    const id = await linto.ensureTag("foo", { categoryName: "missing" })
+    expect(id).toBe("t-created")
+    expect(linto.apiService.listTags).toHaveBeenCalledWith({
+      categoryId: "c-first",
+    })
+  })
+
+  test("ensureTag() returns null when no categories exist", async () => {
+    linto.apiService.listCategories = jest.fn(async () => [])
+    const id = await linto.ensureTag("foo")
+    expect(id).toBeNull()
+  })
+
+  test("ensureTag() returns null when listCategories returns non-array", async () => {
+    linto.apiService.listCategories = jest.fn(async () => ({}))
+    const id = await linto.ensureTag("foo")
+    expect(id).toBeNull()
+  })
+
+  test("addConversationTag() preserves existing tags and appends", async () => {
+    linto.apiService.getConversation = jest.fn(async () => ({
+      _id: "conv-1",
+      tags: ["t-existing"],
+    }))
+    linto.apiService.updateConversation = jest.fn(async () => ({ ok: true }))
+    const res = await linto.addConversationTag("conv-1", "t-new")
+    expect(res).toEqual(["t-existing", "t-new"])
+    expect(linto.apiService.updateConversation).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      data: { tags: ["t-existing", "t-new"] },
+    })
+  })
+
+  test("addConversationTag() does NOT duplicate when tag already present", async () => {
+    linto.apiService.getConversation = jest.fn(async () => ({
+      tags: ["t-existing", "t-dup"],
+    }))
+    linto.apiService.updateConversation = jest.fn()
+    const res = await linto.addConversationTag("conv-1", "t-dup")
+    expect(res).toEqual(["t-existing", "t-dup"])
+    expect(linto.apiService.updateConversation).not.toHaveBeenCalled()
+  })
+
+  test("addConversationTag() returns null when tagId is falsy", async () => {
+    linto.apiService.getConversation = jest.fn()
+    const res = await linto.addConversationTag("conv-1", "")
+    expect(res).toBeNull()
+    expect(linto.apiService.getConversation).not.toHaveBeenCalled()
+  })
+
+  test("addConversationTag() handles conversation with no tags field", async () => {
+    linto.apiService.getConversation = jest.fn(async () => ({ _id: "conv-1" }))
+    linto.apiService.updateConversation = jest.fn(async () => ({ ok: true }))
+    const res = await linto.addConversationTag("conv-1", "t-new")
+    expect(res).toEqual(["t-new"])
+    expect(linto.apiService.updateConversation).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      data: { tags: ["t-new"] },
+    })
+  })
+
+  test("listFolders() forwards default options", async () => {
+    linto.apiService.listFolders = jest.fn(async () => [])
+    await linto.listFolders()
+    expect(linto.apiService.listFolders).toHaveBeenCalledWith({
+      tree: false,
+      withConversationCount: false,
+    })
+  })
+
+  test("listFolders({ tree, withConversationCount }) forwards options", async () => {
+    linto.apiService.listFolders = jest.fn(async () => [])
+    await linto.listFolders({ tree: true, withConversationCount: true })
+    expect(linto.apiService.listFolders).toHaveBeenCalledWith({
+      tree: true,
+      withConversationCount: true,
+    })
+  })
+
+  test("createFolder() forwards full payload with default visibility=public", async () => {
+    linto.apiService.createFolder = jest.fn(async () => ({ _id: "f1" }))
+    await linto.createFolder("myfolder", { parentId: "p1", color: "red" })
+    expect(linto.apiService.createFolder).toHaveBeenCalledWith({
+      name: "myfolder",
+      parentId: "p1",
+      color: "red",
+      emoji: undefined,
+      visibility: "public",
+    })
+  })
+
+  test("createFolder() uses visibility=private when requested", async () => {
+    linto.apiService.createFolder = jest.fn(async () => ({ _id: "f2" }))
+    await linto.createFolder("secret", { visibility: "private" })
+    expect(linto.apiService.createFolder).toHaveBeenCalledWith({
+      name: "secret",
+      parentId: undefined,
+      color: undefined,
+      emoji: undefined,
+      visibility: "private",
+    })
+  })
+
+  test("ensureFolder() finds existing folder by name (case-insensitive) and matching parent", async () => {
+    linto.apiService.listFolders = jest.fn(async () => [
+      { _id: "f-root", name: "Inbox", parentId: null },
+      { _id: "f-child", name: "Inbox", parentId: "p1" },
+    ])
+    linto.apiService.createFolder = jest.fn()
+    const id = await linto.ensureFolder("inbox")
+    expect(id).toBe("f-root")
+    expect(linto.apiService.createFolder).not.toHaveBeenCalled()
+  })
+
+  test("ensureFolder() matches the folder with the same parentId", async () => {
+    linto.apiService.listFolders = jest.fn(async () => [
+      { _id: "f-root", name: "Inbox", parentId: null },
+      { _id: "f-child", name: "Inbox", parentId: "p1" },
+    ])
+    linto.apiService.createFolder = jest.fn()
+    const id = await linto.ensureFolder("inbox", { parentId: "p1" })
+    expect(id).toBe("f-child")
+  })
+
+  test("ensureFolder() creates folder if absent", async () => {
+    linto.apiService.listFolders = jest.fn(async () => [])
+    linto.apiService.createFolder = jest.fn(async () => ({
+      _id: "f-new",
+      name: "n",
+    }))
+    const id = await linto.ensureFolder("n", { visibility: "private" })
+    expect(id).toBe("f-new")
+    expect(linto.apiService.createFolder).toHaveBeenCalledWith({
+      name: "n",
+      parentId: undefined,
+      color: undefined,
+      emoji: undefined,
+      visibility: "private",
+    })
+  })
+
+  test("moveToFolder() POSTs through apiService.moveConversationToFolder", async () => {
+    linto.apiService.moveConversationToFolder = jest.fn(async () => ({
+      ok: true,
+    }))
+    await linto.moveToFolder("f-1", "conv-1")
+    expect(linto.apiService.moveConversationToFolder).toHaveBeenCalledWith({
+      folderId: "f-1",
+      conversationId: "conv-1",
+    })
+  })
+})
+
+describe("StudioApiService Taxonomy — URL/payload via mocked fetch", () => {
+  let originalFetch
+
+  beforeEach(() => {
+    originalFetch = global.fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.clearAllMocks()
+  })
+
+  function makeLinto() {
+    return new LinTO({
+      authToken: "tok-1",
+      baseUrl: "https://example.test",
+    })
+  }
+
+  function defaultOrgHandler(payload = [{ _id: "org-1" }]) {
+    return {
+      match: (req) =>
+        /\/api\/organizations(\?|$)/.test(req.url) ||
+        /\/api\/organizations\?t=/.test(req.url),
+      payload,
+    }
+  }
+
+  test("listCategories GETs /organizations/{orgId}/categories with Bearer token", async () => {
+    const { mock, captured } = makeFetchMock([
+      defaultOrgHandler(),
+      {
+        match: (req) => /\/categories/.test(req.url),
+        payload: [{ _id: "c1", name: "Tags" }],
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.listCategories()
+    expect(res).toEqual([{ _id: "c1", name: "Tags" }])
+    const call = captured.find((c) => c.url.includes("/categories"))
+    expect(call.method).toBe("GET")
+    expect(call.auth).toBe("Bearer tok-1")
+    expect(call.url).toMatch(/\/api\/organizations\/org-1\/categories/)
+  })
+
+  test("listTags GETs /organizations/{orgId}/tags?categoryId=...", async () => {
+    const { mock, captured } = makeFetchMock([
+      defaultOrgHandler(),
+      {
+        match: (req) => /\/tags\?categoryId=/.test(req.url),
+        payload: [{ _id: "t1", name: "x" }],
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.listTags("c1")
+    const tagsCall = captured.find((c) => /\/tags\?categoryId=/.test(c.url))
+    expect(tagsCall.method).toBe("GET")
+    expect(tagsCall.url).toMatch(
+      /\/api\/organizations\/org-1\/tags\?categoryId=c1/
+    )
+  })
+
+  test("createTag POSTs /organizations/{orgId}/tags with full payload", async () => {
+    const { mock, captured } = makeFetchMock([
+      defaultOrgHandler(),
+      {
+        match: (req) =>
+          req.method === "POST" && /\/organizations\/org-1\/tags/.test(req.url),
+        payload: { _id: "t-new", name: "n" },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.apiService.createTag({
+      categoryId: "c1",
+      name: "n",
+      color: "blue",
+    })
+    const postCall = captured.find(
+      (c) =>
+        c.method === "POST" && /\/organizations\/org-1\/tags/.test(c.url)
+    )
+    expect(postCall).toBeDefined()
+    expect(postCall.auth).toBe("Bearer tok-1")
+    const body = JSON.parse(postCall.body)
+    expect(body).toMatchObject({
+      organizationId: "org-1",
+      categoryId: "c1",
+      name: "n",
+      color: "blue",
+    })
+    expect(body).not.toHaveProperty("emoji")
+    expect(body).not.toHaveProperty("description")
+  })
+
+  test("listFolders GETs /organizations/{orgId}/folders with tree/withConversationCount params", async () => {
+    const { mock, captured } = makeFetchMock([
+      defaultOrgHandler(),
+      {
+        match: (req) => /\/folders/.test(req.url),
+        payload: [{ _id: "f1", name: "x" }],
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.apiService.listFolders({
+      tree: true,
+      withConversationCount: true,
+    })
+    const call = captured.find((c) => /\/folders/.test(c.url))
+    expect(call.method).toBe("GET")
+    expect(call.url).toMatch(/\/folders\?tree=true&withConversationCount=true/)
+  })
+
+  test("listFolders without options omits query params on the folders URL", async () => {
+    const { mock, captured } = makeFetchMock([
+      defaultOrgHandler(),
+      {
+        match: (req) => /\/folders/.test(req.url),
+        payload: [],
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.apiService.listFolders()
+    const call = captured.find((c) => /\/folders/.test(c.url))
+    // Folders URL must NOT contain tree= or withConversationCount=
+    expect(call.url).not.toMatch(/tree=/)
+    expect(call.url).not.toMatch(/withConversationCount=/)
+  })
+
+  test("createFolder POSTs /organizations/{orgId}/folders with payload", async () => {
+    const { mock, captured } = makeFetchMock([
+      defaultOrgHandler(),
+      {
+        match: (req) =>
+          req.method === "POST" && /\/organizations\/org-1\/folders/.test(req.url),
+        payload: { _id: "f-new", name: "n" },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.apiService.createFolder({
+      name: "n",
+      parentId: "p1",
+      visibility: "private",
+    })
+    const postCall = captured.find(
+      (c) =>
+        c.method === "POST" && /\/organizations\/org-1\/folders/.test(c.url)
+    )
+    expect(postCall).toBeDefined()
+    const body = JSON.parse(postCall.body)
+    expect(body).toMatchObject({
+      name: "n",
+      parentId: "p1",
+      visibility: "private",
+    })
+  })
+
+  test("moveConversationToFolder POSTs to nested folder/conversation URL", async () => {
+    const { mock, captured } = makeFetchMock([
+      defaultOrgHandler(),
+      {
+        match: (req) =>
+          /\/folders\/f-1\/conversations\/conv-1/.test(req.url) &&
+          req.method === "POST",
+        payload: { ok: true },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.apiService.moveConversationToFolder({
+      folderId: "f-1",
+      conversationId: "conv-1",
+    })
+    const call = captured.find((c) =>
+      /\/folders\/f-1\/conversations\/conv-1/.test(c.url)
+    )
+    expect(call.method).toBe("POST")
+    expect(call.auth).toBe("Bearer tok-1")
+    expect(call.url).toMatch(
+      /\/api\/organizations\/org-1\/folders\/f-1\/conversations\/conv-1/
+    )
+  })
+
+  test("getConversation GETs /conversations/{id}", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) => /\/api\/conversations\/conv-9/.test(req.url),
+        payload: { _id: "conv-9", tags: ["t1"] },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const res = await linto.apiService.getConversation({
+      conversationId: "conv-9",
+    })
+    expect(res).toEqual({ _id: "conv-9", tags: ["t1"] })
+    const call = captured.find((c) => /\/conversations\/conv-9/.test(c.url))
+    expect(call.method).toBe("GET")
+    expect(call.auth).toBe("Bearer tok-1")
+  })
+
+  test("updateConversation PATCHes /conversations/{id} with JSON body", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "PATCH" &&
+          /\/api\/conversations\/conv-7/.test(req.url),
+        payload: { ok: true },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    await linto.apiService.updateConversation({
+      conversationId: "conv-7",
+      data: { tags: ["t-a", "t-b"] },
+    })
+    const call = captured.find(
+      (c) =>
+        c.method === "PATCH" && /\/api\/conversations\/conv-7/.test(c.url)
+    )
+    expect(call).toBeDefined()
+    expect(call.auth).toBe("Bearer tok-1")
+    expect(JSON.parse(call.body)).toEqual({ tags: ["t-a", "t-b"] })
+  })
+
+  test("addConversationTag end-to-end via fetch mock (GET + PATCH)", async () => {
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (req) =>
+          req.method === "GET" && /\/conversations\/conv-3/.test(req.url),
+        payload: { _id: "conv-3", tags: ["old"] },
+      },
+      {
+        match: (req) =>
+          req.method === "PATCH" && /\/conversations\/conv-3/.test(req.url),
+        payload: { ok: true },
+      },
+    ])
+    global.fetch = mock
+    const linto = makeLinto()
+    const newTags = await linto.addConversationTag("conv-3", "fresh")
+    expect(newTags).toEqual(["old", "fresh"])
+    const patchCall = captured.find((c) => c.method === "PATCH")
+    expect(JSON.parse(patchCall.body)).toEqual({ tags: ["old", "fresh"] })
+  })
+})


### PR DESCRIPTION
## Summary

Brings the JavaScript SDK to feature parity with the Python SDK 1.2.6.
The Python SDK exposed 24 public methods; the JS one previously only had 2
(`transcribe`, `listServices`). This PR closes the gap, adds a Jest test
suite from scratch (90 tests, all green), and ships a README + JSDoc.

Bumps `@linto-ai/linto` to **1.2.0**.

### What's added

- **PollingService**: idempotent public `.stop()` + `cancelled` event,
  auto-stop on `done`/`error`.
- **LLM summary**: `listLlmServices()`, `summarize()` returning a new
  `SummaryPollingService` (same pattern as `PollingService`).
- **Taxonomy**: `listCategories`, `listTags`, `createTag`, `ensureTag`
  (defaults to the built-in `"tags"` category — the same fix shipped in
  Python 1.2.6), `addConversationTag` (preserves existing tags, no dup),
  `listFolders`, `createFolder`, `ensureFolder`, `moveToFolder`.
- **Sharing & user management**: `shareConversation` (`notify=false`
  omits the field, matching Python), `searchUsers`, `updateConversation`,
  `setConversationOwner` (case-insensitive email match, clears
  `sharedWithUsers`).
- **Download & publication exports**: `downloadConversation` (binary for
  docx/odt/verbatim, JSON otherwise), `getExportList`, `getExportContent`,
  `getPublicationTemplates`, `getTemplatePlaceholders`,
  `exportWithTemplate` (optional query params omitted when undefined).
- **Tooling**: Jest 29 + jsdom + `--experimental-vm-modules` for the
  ESM-native package. `npm test` runs the full suite.
- **Docs**: complete `README.md` mirroring the Python one + JSDoc on
  every public `LinTO` method.

### Parity

24/24 Python `LinTO` methods now have a JS counterpart. All Python
behavior contracts validated by unit tests (case-insensitive lookups,
fallback to first category, no-duplicate tag append, conditional notify
field, conditional query params, binary vs JSON response handling).

## Test plan

- [x] `npm test` — 90/90 passing across 6 suites (pollingService,
      summaryPollingService, summarize, taxonomy, sharing, exports)
- [x] No regression in the historical `transcribe`/`listServices`
      surface (`test.js` / `test.html` still work; `window.LinTO`
      export preserved)
- [x] Branch built incrementally: 7 atomic commits, one per phase,
      each audited before commit