### PR TITLE
Fix diarization not being sent and add graceful fallback

### DIFF
--- a/studio-sdk/python/linto/services/studioApiService.py
+++ b/studio-sdk/python/linto/services/studioApiService.py
@@ -70,11 +70,27 @@ def with_upload_config(method):
                 f"Check gateway service configuration."
             )
 
+        # Accept both snake_case (PEP 8) and camelCase keys: callers from
+        # within the SDK (e.g. LinTO.transcribe) use snake_case while public
+        # kwargs historically used camelCase. Resolving both avoids the bug
+        # where enable_diarization=True at the caller silently became False.
+        def _pick(*keys, default=None):
+            for key in keys:
+                if key in kwargs:
+                    return kwargs[key]
+            return default
+
         service_config = generate_service_config(
             selected,
-            enable_punctuation=kwargs.get("enablePunctuation", False),
-            enable_diarization=kwargs.get("enableDiarization", False),
-            number_of_speaker=kwargs.get("numberOfSpeaker", 0),
+            enable_punctuation=_pick(
+                "enablePunctuation", "enable_punctuation", default=False
+            ),
+            enable_diarization=_pick(
+                "enableDiarization", "enable_diarization", default=False
+            ),
+            number_of_speaker=_pick(
+                "numberOfSpeaker", "number_of_speaker", default=0
+            ),
             language_value=lang,
         )
 

--- a/studio-sdk/python/linto/services/studioApiService.py
+++ b/studio-sdk/python/linto/services/studioApiService.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime
 from ..models.media import Media
 from ..tools.generate_service_config import generate_service_config
+from ..tools.pick_kwarg import pick_kwarg
 
 def _lang_matches(service_lang, requested_lang):
     if requested_lang == "*":
@@ -74,22 +75,16 @@ def with_upload_config(method):
         # within the SDK (e.g. LinTO.transcribe) use snake_case while public
         # kwargs historically used camelCase. Resolving both avoids the bug
         # where enable_diarization=True at the caller silently became False.
-        def _pick(*keys, default=None):
-            for key in keys:
-                if key in kwargs:
-                    return kwargs[key]
-            return default
-
         service_config = generate_service_config(
             selected,
-            enable_punctuation=_pick(
-                "enablePunctuation", "enable_punctuation", default=False
+            enable_punctuation=pick_kwarg(
+                kwargs, "enablePunctuation", "enable_punctuation", default=False
             ),
-            enable_diarization=_pick(
-                "enableDiarization", "enable_diarization", default=False
+            enable_diarization=pick_kwarg(
+                kwargs, "enableDiarization", "enable_diarization", default=False
             ),
-            number_of_speaker=_pick(
-                "numberOfSpeaker", "number_of_speaker", default=0
+            number_of_speaker=pick_kwarg(
+                kwargs, "numberOfSpeaker", "number_of_speaker", default=0
             ),
             language_value=lang,
         )

--- a/studio-sdk/python/linto/tools/generate_service_config.py
+++ b/studio-sdk/python/linto/tools/generate_service_config.py
@@ -1,4 +1,5 @@
 from .remove_leading_slash import remove_leading_slash
+from .safe_int import safe_int
 
 def generate_service_config(
     service,
@@ -35,12 +36,8 @@ def generate_service_config(
     # (which would silently hang the transcription on the gateway side).
     diarization_effective = bool(enable_diarization and diarization_service)
 
-    # number_of_speaker may arrive as a string (e.g. "0" or "3") since some
-    # callers (Meet backend) pass it through environment-style configuration.
-    try:
-        number_of_speaker_int = int(number_of_speaker) if number_of_speaker is not None else 0
-    except (TypeError, ValueError):
-        number_of_speaker_int = 0
+    # Meet backend may pass number_of_speaker as a string (e.g. "0" or "3").
+    number_of_speaker_int = safe_int(number_of_speaker)
 
     return {
         "serviceName": service["serviceName"],

--- a/studio-sdk/python/linto/tools/generate_service_config.py
+++ b/studio-sdk/python/linto/tools/generate_service_config.py
@@ -28,6 +28,20 @@ def generate_service_config(
         else None
     )
 
+    # Diarization is only effectively enabled when a worker is actually
+    # available for it. When the caller asks for it but the selected ASR
+    # service exposes no diarization sub-service, fall back gracefully
+    # instead of sending enableDiarization=True with serviceName=null
+    # (which would silently hang the transcription on the gateway side).
+    diarization_effective = bool(enable_diarization and diarization_service)
+
+    # number_of_speaker may arrive as a string (e.g. "0" or "3") since some
+    # callers (Meet backend) pass it through environment-style configuration.
+    try:
+        number_of_speaker_int = int(number_of_speaker) if number_of_speaker is not None else 0
+    except (TypeError, ValueError):
+        number_of_speaker_int = 0
+
     return {
         "serviceName": service["serviceName"],
         "endpoint": remove_leading_slash(service["endpoints"][0]["endpoint"]),
@@ -39,13 +53,13 @@ def generate_service_config(
                 "serviceName": punctuation_service,
             },
             "diarizationConfig": {
-                "enableDiarization": enable_diarization,
+                "enableDiarization": diarization_effective,
                 "numberOfSpeaker": (
-                    int(number_of_speaker)
-                    if enable_diarization and number_of_speaker > 0
+                    number_of_speaker_int
+                    if diarization_effective and number_of_speaker_int > 0
                     else None
                 ),
-                "maxNumberOfSpeaker": 100 if enable_diarization else None,
+                "maxNumberOfSpeaker": 100 if diarization_effective else None,
                 "serviceName": diarization_service,
             },
             "enableNormalization": True,

--- a/studio-sdk/python/linto/tools/pick_kwarg.py
+++ b/studio-sdk/python/linto/tools/pick_kwarg.py
@@ -1,0 +1,11 @@
+
+def pick_kwarg(kwargs, *keys, default=None):
+    """Return the first value found in `kwargs` for any of `keys`, else `default`.
+
+    Used to accept both snake_case and camelCase variants of the same option
+    without silently dropping one of them.
+    """
+    for key in keys:
+        if key in kwargs:
+            return kwargs[key]
+    return default

--- a/studio-sdk/python/linto/tools/safe_int.py
+++ b/studio-sdk/python/linto/tools/safe_int.py
@@ -1,0 +1,9 @@
+
+def safe_int(value, default=0):
+    """Convert `value` to int, returning `default` on None or invalid input."""
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/studio-sdk/python/pyproject.toml
+++ b/studio-sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linto"
-version = "1.2.6"
+version = "1.2.8"
 description = "Wrapper around LinTO Studio API"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/studio-sdk/python/tests/test_pick_kwarg.py
+++ b/studio-sdk/python/tests/test_pick_kwarg.py
@@ -1,0 +1,42 @@
+"""Tests for the pick_kwarg helper."""
+
+from linto.tools.pick_kwarg import pick_kwarg
+
+
+class TestPickKwarg:
+    def test_returns_value_when_first_key_matches(self):
+        kwargs = {"enableDiarization": True}
+        assert pick_kwarg(kwargs, "enableDiarization", "enable_diarization") is True
+
+    def test_returns_value_when_second_key_matches(self):
+        kwargs = {"enable_diarization": True}
+        assert pick_kwarg(kwargs, "enableDiarization", "enable_diarization") is True
+
+    def test_first_key_takes_precedence_over_later_keys(self):
+        kwargs = {"enableDiarization": "first", "enable_diarization": "second"}
+        assert pick_kwarg(kwargs, "enableDiarization", "enable_diarization") == "first"
+
+    def test_returns_default_when_no_key_matches(self):
+        assert pick_kwarg({}, "a", "b", default="fallback") == "fallback"
+
+    def test_default_is_none_when_unset(self):
+        assert pick_kwarg({}, "a", "b") is None
+
+    def test_falsy_values_are_returned_not_skipped(self):
+        # False / 0 / "" are valid values and must override the default.
+        assert pick_kwarg({"flag": False}, "flag", default=True) is False
+        assert pick_kwarg({"count": 0}, "count", default=42) == 0
+        assert pick_kwarg({"name": ""}, "name", default="x") == ""
+
+    def test_none_value_is_returned_not_skipped(self):
+        # An explicit None in kwargs must win over the default.
+        assert pick_kwarg({"x": None}, "x", default="fallback") is None
+
+    def test_works_with_single_key(self):
+        assert pick_kwarg({"x": 1}, "x") == 1
+        assert pick_kwarg({}, "x", default=7) == 7
+
+    def test_does_not_mutate_kwargs(self):
+        kwargs = {"a": 1}
+        pick_kwarg(kwargs, "missing", default="x")
+        assert kwargs == {"a": 1}

--- a/studio-sdk/python/tests/test_safe_int.py
+++ b/studio-sdk/python/tests/test_safe_int.py
@@ -1,0 +1,36 @@
+"""Tests for the safe_int helper."""
+
+from linto.tools.safe_int import safe_int
+
+
+class TestSafeInt:
+    def test_returns_int_unchanged(self):
+        assert safe_int(3) == 3
+        assert safe_int(0) == 0
+        assert safe_int(-5) == -5
+
+    def test_parses_numeric_string(self):
+        assert safe_int("3") == 3
+        assert safe_int("0") == 0
+        assert safe_int("-7") == -7
+
+    def test_returns_default_on_none(self):
+        assert safe_int(None) == 0
+        assert safe_int(None, default=42) == 42
+
+    def test_returns_default_on_invalid_string(self):
+        assert safe_int("abc") == 0
+        assert safe_int("", default=10) == 10
+        assert safe_int("3.5") == 0  # int() rejects decimal strings
+
+    def test_returns_default_on_unsupported_type(self):
+        assert safe_int([1, 2], default=99) == 99
+        assert safe_int({"a": 1}, default=99) == 99
+
+    def test_truncates_float(self):
+        # int() truncates floats — keep the same behavior.
+        assert safe_int(3.7) == 3
+        assert safe_int(-3.7) == -3
+
+    def test_default_is_zero_when_unset(self):
+        assert safe_int("nope") == 0

--- a/studio-sdk/python/tests/test_upload_config.py
+++ b/studio-sdk/python/tests/test_upload_config.py
@@ -200,3 +200,179 @@ class TestTranscriptionConfigLanguage:
         config = json.loads(captured["transcriptionConfig"])
         assert config["language"] == "fr"
         assert captured["lang"] == "fr"
+
+
+@pytest.mark.asyncio
+class TestDiarizationPropagation:
+    """Regression tests for the snake_case vs camelCase naming mismatch
+    between LinTO.transcribe() and the with_upload_config decorator.
+
+    Before the fix, enable_diarization=True at the caller silently became
+    False inside generate_service_config because the decorator only checked
+    for the camelCase key.
+    """
+
+    @staticmethod
+    def _service_with_diarization():
+        return {
+            "serviceName": "stt-fr",
+            "language": "fr-FR",
+            "scope": ["stt"],
+            "endpoints": [{"endpoint": "/stt-fr"}],
+            "model_type": "whisper",
+            "sub_services": {
+                "diarization": [{"service_name": "stt-diarization"}],
+                "punctuation": [],
+            },
+        }
+
+    @staticmethod
+    def _service_without_diarization():
+        return {
+            "serviceName": "stt-fr",
+            "language": "fr-FR",
+            "scope": ["stt"],
+            "endpoints": [{"endpoint": "/stt-fr"}],
+            "model_type": "whisper",
+            "sub_services": {"diarization": [], "punctuation": []},
+        }
+
+    async def _capture_transcription_config(
+        self, monkeypatch, service=None, **transcribe_kwargs
+    ):
+        captured = {}
+
+        async def fake_send_request(self_, method, url, **kwargs):
+            data = kwargs.get("data")
+            if data is not None:
+                for field in data._fields:
+                    captured[field[0]["name"]] = field[2]
+            return {"conversationId": "conv-1"}
+
+        monkeypatch.setattr(StudioApiService, "_send_request", fake_send_request)
+
+        client = LinTO(auth_token="dummy", base_url="http://test")
+        client.api_service.asr_services = [service or self._service_with_diarization()]
+        client.api_service.organizations = [{"_id": "org-1"}]
+
+        await client.transcribe(file=b"audio", **transcribe_kwargs)
+        return json.loads(captured["transcriptionConfig"])
+
+    async def test_snake_case_enable_diarization_reaches_config(self, monkeypatch):
+        config = await self._capture_transcription_config(
+            monkeypatch, language="fr", enable_diarization=True
+        )
+        assert config["diarizationConfig"]["enableDiarization"] is True
+        assert config["diarizationConfig"]["serviceName"] == "stt-diarization"
+
+    async def test_camel_case_enableDiarization_reaches_config(self, monkeypatch):
+        # Bypass the LinTO.transcribe wrapper so we can send camelCase.
+        captured = {}
+
+        async def fake_send_request(self_, method, url, **kwargs):
+            data = kwargs.get("data")
+            if data is not None:
+                for field in data._fields:
+                    captured[field[0]["name"]] = field[2]
+            return {"conversationId": "conv-1"}
+
+        monkeypatch.setattr(StudioApiService, "_send_request", fake_send_request)
+
+        service = StudioApiService(token="dummy")
+        service.asr_services = [self._service_with_diarization()]
+        service.organizations = [{"_id": "org-1"}]
+
+        await service.upload_file(file=b"audio", lang="fr", enableDiarization=True)
+
+        config = json.loads(captured["transcriptionConfig"])
+        assert config["diarizationConfig"]["enableDiarization"] is True
+        assert config["diarizationConfig"]["serviceName"] == "stt-diarization"
+
+    async def test_diarization_off_by_default(self, monkeypatch):
+        config = await self._capture_transcription_config(
+            monkeypatch, language="fr", enable_diarization=False
+        )
+        assert config["diarizationConfig"]["enableDiarization"] is False
+        assert config["diarizationConfig"]["serviceName"] is None
+
+    async def test_number_of_speaker_snake_case_reaches_config(self, monkeypatch):
+        config = await self._capture_transcription_config(
+            monkeypatch,
+            language="fr",
+            enable_diarization=True,
+            number_of_speaker="3",
+        )
+        assert config["diarizationConfig"]["numberOfSpeaker"] == 3
+
+
+@pytest.mark.asyncio
+class TestDiarizationGracefulFallback:
+    """Regression tests: when the caller requests diarization but the selected
+    ASR service exposes no diarization sub-service, the SDK must fall back
+    gracefully (enableDiarization=False) instead of sending a payload with
+    enableDiarization=True + serviceName=null — which silently hangs the
+    transcription on the gateway side.
+    """
+
+    @staticmethod
+    def _build_service(diarization_workers=()):
+        return {
+            "serviceName": "stt-fr",
+            "language": "fr-FR",
+            "scope": ["stt"],
+            "endpoints": [{"endpoint": "/stt-fr"}],
+            "model_type": "whisper",
+            "sub_services": {
+                "diarization": [
+                    {"service_name": name} for name in diarization_workers
+                ],
+                "punctuation": [],
+            },
+        }
+
+    async def _capture(self, monkeypatch, service, **kwargs):
+        captured = {}
+
+        async def fake_send_request(self_, method, url, **request_kwargs):
+            data = request_kwargs.get("data")
+            if data is not None:
+                for field in data._fields:
+                    captured[field[0]["name"]] = field[2]
+            return {"conversationId": "conv-1"}
+
+        monkeypatch.setattr(StudioApiService, "_send_request", fake_send_request)
+
+        client = LinTO(auth_token="dummy", base_url="http://test")
+        client.api_service.asr_services = [service]
+        client.api_service.organizations = [{"_id": "org-1"}]
+
+        await client.transcribe(file=b"audio", **kwargs)
+        return json.loads(captured["transcriptionConfig"])
+
+    async def test_falls_back_when_no_diarization_worker(self, monkeypatch):
+        """Requesting diarization on a service without workers MUST result
+        in enableDiarization=False, serviceName=null, numberOfSpeaker=null."""
+        config = await self._capture(
+            monkeypatch,
+            self._build_service(diarization_workers=()),
+            language="fr",
+            enable_diarization=True,
+            number_of_speaker="2",
+        )
+        diar = config["diarizationConfig"]
+        assert diar["enableDiarization"] is False, "Fallback must disable"
+        assert diar["serviceName"] is None
+        assert diar["numberOfSpeaker"] is None
+        assert diar["maxNumberOfSpeaker"] is None
+
+    async def test_enabled_when_diarization_worker_present(self, monkeypatch):
+        """Sanity: with a worker, enableDiarization stays True."""
+        config = await self._capture(
+            monkeypatch,
+            self._build_service(diarization_workers=["stt-diar-1"]),
+            language="fr",
+            enable_diarization=True,
+        )
+        diar = config["diarizationConfig"]
+        assert diar["enableDiarization"] is True
+        assert diar["serviceName"] == "stt-diar-1"


### PR DESCRIPTION
## Summary

Diarization was silently disabled even when callers passed
`enable_diarization=True` via `LinTO.transcribe()`. Two independent
bugs were responsible.

### 1. Naming mismatch (snake_case vs camelCase)

`with_upload_config` read `enableDiarization` (camelCase) from kwargs,
but PEP-8 callers including `LinTO.transcribe()` pass
`enable_diarization` (snake_case). The key never matched and the
decorator defaulted the value to `False` before `generate_service_config`
ever saw it. Same mismatch on `number_of_speaker` and consistency
problem on `enable_punctuation`. The decorator now accepts both.

### 2. Missing fallback when no diarization worker is available

`generate_service_config` produced `enableDiarization: true` with
`serviceName: null` when the selected ASR service exposed no
diarization sub-service. The transcription gateway could not dispatch
the task and it stayed stuck, surfacing as a generic
"LinTO Studio transcription failed". Now the payload reflects
reality: `enableDiarization` is only `true` when a worker is actually
selectable, and `numberOfSpeaker`/`maxNumberOfSpeaker` follow suit.

Also hardens `number_of_speaker` to accept stringified values, since
Meet's backend passes `"0"` from its env-style configuration.

## Test plan

- [x] `pytest tests/test_upload_config.py` — 27/27 passing
- [x] New tests cover: snake_case propagation, camelCase still works,
  diarization off by default, stringified speaker count, graceful
  fallback when no worker, worker-present sanity check
- [x] Bumps SDK to **1.2.8**; will be published to PyPI once merged