### PR TITLE
Opt-in M2M users in organization listing

### DIFF
--- a/studio-api/components/WebServer/routecontrollers/organizations/organizations.js
+++ b/studio-api/components/WebServer/routecontrollers/organizations/organizations.js
@@ -51,9 +51,18 @@ async function getOrganization(req, res, next) {
 
     let organization = lorganization[0]
 
-    organization.users = organization.users.filter(
-      (u) => u.type !== USER_TYPE.M2M,
-    )
+    // M2M users (API keys) are excluded by default to preserve the
+    // legacy contract: most UIs (members listing, permission pickers)
+    // only want human members. Opt-in via ?includeM2m=true when the
+    // caller needs to resolve a conversation/media owner that may be
+    // an API key.
+    const includeM2m =
+      req.query.includeM2m === "true" || req.query.includeM2m === true
+    if (!includeM2m) {
+      organization.users = organization.users.filter(
+        (u) => u.type !== USER_TYPE.M2M,
+      )
+    }
 
     let orgaUser = []
 

--- a/studio-frontend/src/api/organisation.js
+++ b/studio-frontend/src/api/organisation.js
@@ -4,9 +4,16 @@ import { getEnv } from "@/tools/getEnv"
 
 const BASE_API = getEnv("VUE_APP_CONVO_API")
 
-export async function apiGetOrganizationById(organizationId, notif) {
+export async function apiGetOrganizationById(
+  organizationId,
+  notif,
+  { includeM2m = false } = {},
+) {
+  const url = includeM2m
+    ? `${BASE_API}/organizations/${organizationId}?includeM2m=true`
+    : `${BASE_API}/organizations/${organizationId}`
   const getOrganization = await sendRequest(
-    `${BASE_API}/organizations/${organizationId}`,
+    url,
     { method: "get" },
     null,
     notif,

--- a/studio-frontend/src/components-mobile/MediaExplorerItem.vue
+++ b/studio-frontend/src/components-mobile/MediaExplorerItem.vue
@@ -116,6 +116,7 @@ export default {
   computed: {
     ...mapGetters("organizations", {
       currentOrganizationUsers: "getCurrentOrganizationUsers",
+      currentOrganizationAllUsers: "getCurrentOrganizationAllUsers",
       currentOrganization: "getCurrentOrganization",
     }),
     title() {
@@ -141,7 +142,12 @@ export default {
         }
       }
 
-      const userList = this.currentOrganizationUsers
+      // Look up the owner in the M2M-augmented list first so an API key
+      // (e.g. an automated transcription service) shows its real name and
+      // avatar. Fall back to the members list before it is loaded.
+      const augmented = this.currentOrganizationAllUsers
+      const fallback = this.currentOrganizationUsers
+      const userList = augmented.length > 0 ? augmented : fallback
       const owner = userList.find((u) => u._id == this.media.owner)
       if (owner) {
         return {

--- a/studio-frontend/src/components/ConversationOverviewRights.vue
+++ b/studio-frontend/src/components/ConversationOverviewRights.vue
@@ -68,9 +68,15 @@ export default {
   computed: {
     ...mapGetters("organizations", {
       currentOrganizationUsers: "getCurrentOrganizationUsers",
+      currentOrganizationAllUsers: "getCurrentOrganizationAllUsers",
     }),
     convOwner() {
-      const userList = this.currentOrganizationUsers
+      // Look up the owner in the M2M-augmented list first so an API key
+      // (e.g. an automated transcription service) shows its real name and
+      // avatar. Fall back to the members list before it is loaded.
+      const augmented = this.currentOrganizationAllUsers
+      const fallback = this.currentOrganizationUsers
+      const userList = augmented.length > 0 ? augmented : fallback
       const owner = userList.find((u) => u._id == this.conversation.owner)
       if (owner) {
         return {

--- a/studio-frontend/src/components/MediaExplorer.vue
+++ b/studio-frontend/src/components/MediaExplorer.vue
@@ -179,7 +179,13 @@ export default {
       selectedMediaIds: [],
     }
   },
-  mounted() {},
+  mounted() {
+    // Lazily load M2M-augmented users so the owner of a media created by
+    // an API key (e.g. an automated Meet transcription) can be resolved
+    // with its real name and avatar instead of falling back to
+    // "Private user" + the default picture.
+    this.$store.dispatch("organizations/loadCurrentOrganizationAllUsers")
+  },
   beforeDestroy() {
     this.cleanupObserver()
   },

--- a/studio-frontend/src/components/MediaExplorerItem.vue
+++ b/studio-frontend/src/components/MediaExplorerItem.vue
@@ -222,6 +222,7 @@ export default {
   computed: {
     ...mapGetters("organizations", {
       currentOrganizationUsers: "getCurrentOrganizationUsers",
+      currentOrganizationAllUsers: "getCurrentOrganizationAllUsers",
       currentOrganization: "getCurrentOrganization",
     }),
 
@@ -339,7 +340,13 @@ export default {
         }
       }
 
-      const userList = this.currentOrganizationUsers
+      // Look up the owner in the M2M-augmented list first so an API key
+      // (used by automated services like meeting recorders) shows its real
+      // name and avatar. Fall back to the regular members list when the
+      // augmented one has not been loaded yet.
+      const augmented = this.currentOrganizationAllUsers
+      const fallback = this.currentOrganizationUsers
+      const userList = augmented.length > 0 ? augmented : fallback
       const owner = userList.find((u) => u._id == this.media.owner)
       if (owner) {
         return {

--- a/studio-frontend/src/store/organizations/actions.js
+++ b/studio-frontend/src/store/organizations/actions.js
@@ -60,12 +60,41 @@ const actions = {
 
     commit("setCurrentOrganization", organization)
     commit("setCurrentOrganizationScope", organizationId)
+    // Reset the M2M-augmented cache: it belongs to the previous org.
+    commit("setCurrentOrganizationAllUsers", [])
 
     // Clear selected tags when switching organizations
     await dispatch("tags/clearExploreSelectedTags", null, { root: true })
   },
   async setCurrentFilterStatus({ commit }, status) {
     commit("setCurrentFilterStatus", status)
+  },
+  /**
+   * Load the current organization with M2M users (API keys) included in
+   * the users array. Stored separately from currentOrganization to avoid
+   * leaking API keys into UIs that only want human members.
+   *
+   * Idempotent: subsequent calls reuse the cached value unless forceRefresh.
+   */
+  async loadCurrentOrganizationAllUsers(
+    { commit, state },
+    { forceRefresh = false } = {},
+  ) {
+    const organizationId = state.currentOrganizationScope
+    if (!organizationId) return []
+    if (
+      !forceRefresh &&
+      state.currentOrganizationAllUsers &&
+      state.currentOrganizationAllUsers.length > 0
+    ) {
+      return state.currentOrganizationAllUsers
+    }
+    const organization = await apiGetOrganizationById(organizationId, null, {
+      includeM2m: true,
+    })
+    const users = organization?.users ?? []
+    commit("setCurrentOrganizationAllUsers", users)
+    return users
   },
 }
 

--- a/studio-frontend/src/store/organizations/getters.js
+++ b/studio-frontend/src/store/organizations/getters.js
@@ -42,6 +42,13 @@ const getters = {
   getCurrentOrganizationUsers(state) {
     return state.currentOrganization?.users ?? []
   },
+  // Members + M2M (API keys). Populated lazily by
+  // `loadCurrentOrganizationAllUsers`. Use this getter for owner lookups
+  // (a media owner can be an API key). Do NOT use it for member listings
+  // or invitation pickers — `getCurrentOrganizationUsers` excludes M2M.
+  getCurrentOrganizationAllUsers(state) {
+    return state.currentOrganizationAllUsers ?? []
+  },
   getUserRoleInOrganization: (state, getters, rootState, rootGetters) => {
     let organization = getters.getCurrentOrganization
     const userId = rootGetters["user/getUserId"]

--- a/studio-frontend/src/store/organizations/mutations.js
+++ b/studio-frontend/src/store/organizations/mutations.js
@@ -18,6 +18,9 @@ const mutations = {
   setCurrentOrganization(state, organization) {
     state.currentOrganization = organization
   },
+  setCurrentOrganizationAllUsers(state, users) {
+    state.currentOrganizationAllUsers = Array.isArray(users) ? users : []
+  },
   deleteOrganization(state, id) {
     delete state.organizations[id]
     state.rolesInOrganizations.delete(id)

--- a/studio-frontend/src/store/organizations/state.js
+++ b/studio-frontend/src/store/organizations/state.js
@@ -5,6 +5,11 @@ const state = {
   currentOrganization: null,
   currentScope: null, // "organization" or "favorites" or "shared"
   currentFilterStatus: "done", // done, processing, error
+  // Full member list including M2M users (API keys). Loaded lazily when a
+  // consumer needs to resolve a media/conversation owner that may be an
+  // API key. Kept separate from currentOrganization.users so that human
+  // member listings (pickers, invitation UIs) stay unaffected.
+  currentOrganizationAllUsers: [],
 }
 
 export default state

--- a/studio-frontend/src/views/ConversationsOverview.vue
+++ b/studio-frontend/src/views/ConversationsOverview.vue
@@ -110,7 +110,12 @@ export default {
       loadingAudio: false,
     }
   },
-  mounted() {},
+  mounted() {
+    // Make sure the M2M-augmented user list is available so the owner of a
+    // conversation created by an API key renders with its real name and
+    // avatar.
+    this.$store.dispatch("organizations/loadCurrentOrganizationAllUsers")
+  },
   watch: {
     dataLoaded(data) {
       if (data) {


### PR DESCRIPTION
## Summary

`GET /organizations/{id}` silently filtered M2M users (API keys) from
the returned org payload. That excluded API key owners from
`currentOrganization.users` on the frontend, so any media or
conversation created by an API key fell back to the generic
"Private user" + default avatar in the UI.

Removing the filter outright would leak API keys into member listings
and permission pickers, which is unwanted. Instead, this PR exposes
an **opt-in query parameter** and loads the augmented list lazily on
the surfaces that need it.

### Backend

- `GET /organizations/{id}` accepts `?includeM2m=true`.
- Default behavior is **unchanged** (M2M filtered out), preserving the
  contract for member listings, invitation UIs and permission pickers.

### Frontend

- `apiGetOrganizationById` accepts `{ includeM2m }`.
- New Vuex slice `currentOrganizationAllUsers` + getter
  `getCurrentOrganizationAllUsers` + action
  `loadCurrentOrganizationAllUsers`. Reset on org scope change.
- `MediaExplorer.vue` and `ConversationsOverview.vue` dispatch the
  loader on mount.
- The augmented list is consulted only by owner-resolution code paths:
  `MediaExplorerItem.vue` (desktop + mobile) and
  `ConversationOverviewRights.vue` look up the conversation owner in
  the augmented list first and fall back to the regular members list
  before it is loaded.
- Member listings, permission pickers and search results keep using
  `getCurrentOrganizationUsers`, so they remain M2M-free.

## Result

API keys (e.g. an automated transcription service) display their
real `firstname` and avatar on media they own, without polluting
human-only UIs.

## Test plan

- [x] Backend: `?includeM2m=true` returns M2M users; default still filters.
- [x] Frontend: media created by an API key shows the API key's name +
      avatar instead of "Private user" + default picture.
- [x] Member listings, permission pickers, share search remain
      unaffected (still consume `getCurrentOrganizationUsers`).
- [x] Switching organization resets the augmented cache.