### PR TITLE
Allow uploading an avatar for an API key + resolve M2M owners in the media explorer

### DIFF
--- a/studio-api/components/WebServer/controllers/apikey/token.js
+++ b/studio-api/components/WebServer/controllers/apikey/token.js
@@ -114,6 +114,7 @@ async function listApiKey(idList, orgaRoles = undefined) {
     firstname: true,
     lastname: true,
     role: true,
+    img: true,
     tokenCreatedAt: true,
     tokenExpiresAt: true,
   }

--- a/studio-api/components/WebServer/routecontrollers/organizations/apiKey.js
+++ b/studio-api/components/WebServer/routecontrollers/organizations/apiKey.js
@@ -9,7 +9,7 @@ const { OrganizationUnsupportedMediaType } = require(
   `${process.cwd()}/components/WebServer/error/exception/organization`,
 )
 
-const { UserError } = require(
+const { UserError, UserUnsupportedMediaType } = require(
   `${process.cwd()}/components/WebServer/error/exception/users`,
 )
 const ROLES = require(`${process.cwd()}/lib/dao/organization/roles`)
@@ -23,6 +23,30 @@ const TokenHandler = require(
   `${process.cwd()}/components/WebServer/controllers/apikey/token`,
 )
 const { requireParam } = require(`${process.cwd()}/lib/utility/requireParam`)
+
+const { storeFile, defaultPicture, deleteFile, getStorageFolder } = require(
+  `${process.cwd()}/components/WebServer/controllers/files/store`,
+)
+
+const ACCEPTED_PICTURE_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/bmp",
+  "image/webp",
+]
+
+// Remove a user's custom picture from disk so we do not leak orphan files.
+// The default picture is shared with every user without a custom one — it
+// must never be deleted.
+function deletePictureIfCustom(img) {
+  if (!img || img === defaultPicture()) return
+  try {
+    deleteFile(`${getStorageFolder()}/${img}`)
+  } catch (err) {
+    debug("Failed to remove API key picture %s: %s", img, err.message)
+  }
+}
 
 async function checkTokenBelongsToOrganization(params) {
   try {
@@ -133,7 +157,13 @@ async function getApiKey(req, res, next) {
 
 async function deleteApiKey(req, res, next) {
   try {
-    const { organization } = await checkTokenBelongsToOrganization(req.params)
+    const { organization, user } = await checkTokenBelongsToOrganization(
+      req.params,
+    )
+
+    // Clean up the custom picture file (if any) before deleting the user
+    // so we do not leak orphan files on disk.
+    deletePictureIfCustom(user.img)
 
     organization.users = organization.users.filter(
       (oUser) => oUser.userId !== req.params.tokenId,
@@ -151,10 +181,49 @@ async function deleteApiKey(req, res, next) {
   }
 }
 
+async function updateApiKeyPicture(req, res, next) {
+  try {
+    if (
+      !req.files ||
+      Object.keys(req.files).length === 0 ||
+      !req.files.file
+    ) {
+      throw new UserUnsupportedMediaType("Image file is required")
+    }
+
+    const file = req.files.file
+    if (!ACCEPTED_PICTURE_MIME_TYPES.includes(file.mimetype)) {
+      throw new UserUnsupportedMediaType(
+        `Invalid image type ${file.mimetype}. Accepted: ${ACCEPTED_PICTURE_MIME_TYPES.join(", ")}`,
+      )
+    }
+
+    const { user } = await checkTokenBelongsToOrganization(req.params)
+
+    const imagePath = await storeFile(file, "picture")
+
+    deletePictureIfCustom(user.img)
+
+    const result = await model.users.update({
+      _id: req.params.tokenId,
+      img: imagePath,
+    })
+    if (result.matchedCount === 0) throw new UserError("API key not updated")
+
+    res.status(200).send({
+      message: "API key picture updated",
+      img: imagePath,
+    })
+  } catch (err) {
+    next(err)
+  }
+}
+
 module.exports = {
   createApiKey,
   listApiKeyFromOrga,
   refreshApiKey,
   getApiKey,
   deleteApiKey,
+  updateApiKeyPicture,
 }

--- a/studio-api/components/WebServer/routecontrollers/organizations/organizations.js
+++ b/studio-api/components/WebServer/routecontrollers/organizations/organizations.js
@@ -51,9 +51,18 @@ async function getOrganization(req, res, next) {
 
     let organization = lorganization[0]
 
-    organization.users = organization.users.filter(
-      (u) => u.type !== USER_TYPE.M2M,
-    )
+    // M2M users (API keys) are excluded by default to preserve the
+    // legacy contract: most UIs (members listing, permission pickers)
+    // only want human members. Opt-in via ?includeM2m=true when the
+    // caller needs to resolve a conversation/media owner that may be
+    // an API key.
+    const includeM2m =
+      req.query.includeM2m === "true" || req.query.includeM2m === true
+    if (!includeM2m) {
+      organization.users = organization.users.filter(
+        (u) => u.type !== USER_TYPE.M2M,
+      )
+    }
 
     let orgaUser = []
 

--- a/studio-api/components/WebServer/routes/api/organization/organizations.js
+++ b/studio-api/components/WebServer/routes/api/organization/organizations.js
@@ -31,6 +31,7 @@ const {
   getApiKey,
   refreshApiKey,
   deleteApiKey,
+  updateApiKeyPicture,
 } = require(
   `${process.cwd()}/components/WebServer/routecontrollers/organizations/apiKey.js`,
 )
@@ -201,6 +202,13 @@ module.exports = (webserver) => {
       requireAuth: true,
       requireOrganizationAdminAccess: true,
       controller: deleteApiKey,
+    },
+    {
+      path: "/:organizationId/tokens/:tokenId/picture",
+      method: "put",
+      requireAuth: true,
+      requireOrganizationAdminAccess: true,
+      controller: updateApiKeyPicture,
     },
   ]
 }

--- a/studio-frontend/src/api/organisation.js
+++ b/studio-frontend/src/api/organisation.js
@@ -4,9 +4,16 @@ import { getEnv } from "@/tools/getEnv"
 
 const BASE_API = getEnv("VUE_APP_CONVO_API")
 
-export async function apiGetOrganizationById(organizationId, notif) {
+export async function apiGetOrganizationById(
+  organizationId,
+  notif,
+  { includeM2m = false } = {},
+) {
+  const url = includeM2m
+    ? `${BASE_API}/organizations/${organizationId}?includeM2m=true`
+    : `${BASE_API}/organizations/${organizationId}`
   const getOrganization = await sendRequest(
-    `${BASE_API}/organizations/${organizationId}`,
+    url,
     { method: "get" },
     null,
     notif,

--- a/studio-frontend/src/api/token.js
+++ b/studio-frontend/src/api/token.js
@@ -1,4 +1,5 @@
 import { sendRequest } from "../tools/sendRequest"
+import { sendMultipartFormData } from "../tools/sendMultipartFormData"
 import { getEnv } from "@/tools/getEnv"
 
 const BASE_API = getEnv("VUE_APP_CONVO_API")
@@ -59,4 +60,19 @@ export async function apiRenewToken(organizationId, tokenId, { expiration }) {
   )
 
   return res
+}
+
+/**
+ * Upload (or replace) the avatar of an API key.
+ * The file is sent as multipart/form-data on field `file`.
+ */
+export async function apiUpdateTokenPicture(organizationId, tokenId, file) {
+  const formData = new FormData()
+  formData.append("file", file)
+  return await sendMultipartFormData(
+    `${BASE_API}/organizations/${organizationId}/tokens/${tokenId}/picture`,
+    "put",
+    formData,
+    null,
+  )
 }

--- a/studio-frontend/src/components-mobile/MediaExplorerItem.vue
+++ b/studio-frontend/src/components-mobile/MediaExplorerItem.vue
@@ -116,6 +116,7 @@ export default {
   computed: {
     ...mapGetters("organizations", {
       currentOrganizationUsers: "getCurrentOrganizationUsers",
+      currentOrganizationAllUsers: "getCurrentOrganizationAllUsers",
       currentOrganization: "getCurrentOrganization",
     }),
     title() {
@@ -141,7 +142,12 @@ export default {
         }
       }
 
-      const userList = this.currentOrganizationUsers
+      // Look up the owner in the M2M-augmented list first so an API key
+      // (e.g. an automated transcription service) shows its real name and
+      // avatar. Fall back to the members list before it is loaded.
+      const augmented = this.currentOrganizationAllUsers
+      const fallback = this.currentOrganizationUsers
+      const userList = augmented.length > 0 ? augmented : fallback
       const owner = userList.find((u) => u._id == this.media.owner)
       if (owner) {
         return {

--- a/studio-frontend/src/components/ApiTokenTable.vue
+++ b/studio-frontend/src/components/ApiTokenTable.vue
@@ -10,7 +10,14 @@
       idKey="userId"
       @list_sort_by="sortBy">
       <template #cell-firstname="{ element }">
-        {{ element.firstname }}
+        <div class="flex gap-small align-center">
+          <Avatar
+            color="#dadada"
+            size="sm"
+            :text="(element.firstname || '?').substring(0, 1)"
+            :src="element.avatarSrc" />
+          <span>{{ element.firstname }}</span>
+        </div>
       </template>
       <template #cell-organizationRole="{ element }">
         <OrgaRoleSelector v-model="element.organizationRole" readonly />
@@ -76,6 +83,7 @@
 
 <script>
 import { apiGetToken } from "@/api/token"
+import Avatar from "@/components/atoms/Avatar.vue"
 import Chip from "@/components/atoms/Chip.vue"
 import GenericTable from "@/components/molecules/GenericTable.vue"
 import OrgaRoleSelector from "./molecules/OrgaRoleSelector.vue"
@@ -84,6 +92,7 @@ import ModalRenewToken from "./ModalRenewToken.vue"
 import ModalViewToken from "./ModalViewToken.vue"
 import { formatDateLocale } from "@/tools/formatDate"
 import { isTokenExpiringSoon } from "@/tools/isTokenExpiringSoon"
+import userAvatar from "@/tools/userAvatar"
 
 export default {
   props: {
@@ -156,6 +165,11 @@ export default {
       return this.tokenList.map((token) => ({
         ...token,
         expiringSoon: isTokenExpiringSoon(token, now),
+        // Precompute the avatar URL once per list change instead of on
+        // every row re-render. Null when the API key has no custom picture
+        // so the Avatar component falls back to its initial rather than
+        // the generic default user picture.
+        avatarSrc: token?.img ? userAvatar(token) : null,
       }))
     },
   },
@@ -218,6 +232,7 @@ export default {
     },
   },
   components: {
+    Avatar,
     Chip,
     GenericTable,
     OrgaRoleSelector,

--- a/studio-frontend/src/components/ConversationOverviewRights.vue
+++ b/studio-frontend/src/components/ConversationOverviewRights.vue
@@ -68,9 +68,15 @@ export default {
   computed: {
     ...mapGetters("organizations", {
       currentOrganizationUsers: "getCurrentOrganizationUsers",
+      currentOrganizationAllUsers: "getCurrentOrganizationAllUsers",
     }),
     convOwner() {
-      const userList = this.currentOrganizationUsers
+      // Look up the owner in the M2M-augmented list first so an API key
+      // (e.g. an automated transcription service) shows its real name and
+      // avatar. Fall back to the members list before it is loaded.
+      const augmented = this.currentOrganizationAllUsers
+      const fallback = this.currentOrganizationUsers
+      const userList = augmented.length > 0 ? augmented : fallback
       const owner = userList.find((u) => u._id == this.conversation.owner)
       if (owner) {
         return {

--- a/studio-frontend/src/components/MediaExplorer.vue
+++ b/studio-frontend/src/components/MediaExplorer.vue
@@ -179,7 +179,13 @@ export default {
       selectedMediaIds: [],
     }
   },
-  mounted() {},
+  mounted() {
+    // Lazily load M2M-augmented users so the owner of a media created by
+    // an API key (e.g. an automated Meet transcription) can be resolved
+    // with its real name and avatar instead of falling back to
+    // "Private user" + the default picture.
+    this.$store.dispatch("organizations/loadCurrentOrganizationAllUsers")
+  },
   beforeDestroy() {
     this.cleanupObserver()
   },

--- a/studio-frontend/src/components/MediaExplorerItem.vue
+++ b/studio-frontend/src/components/MediaExplorerItem.vue
@@ -222,6 +222,7 @@ export default {
   computed: {
     ...mapGetters("organizations", {
       currentOrganizationUsers: "getCurrentOrganizationUsers",
+      currentOrganizationAllUsers: "getCurrentOrganizationAllUsers",
       currentOrganization: "getCurrentOrganization",
     }),
 
@@ -339,7 +340,13 @@ export default {
         }
       }
 
-      const userList = this.currentOrganizationUsers
+      // Look up the owner in the M2M-augmented list first so an API key
+      // (used by automated services like meeting recorders) shows its real
+      // name and avatar. Fall back to the regular members list when the
+      // augmented one has not been loaded yet.
+      const augmented = this.currentOrganizationAllUsers
+      const fallback = this.currentOrganizationUsers
+      const userList = augmented.length > 0 ? augmented : fallback
       const owner = userList.find((u) => u._id == this.media.owner)
       if (owner) {
         return {

--- a/studio-frontend/src/components/ModalCreateToken.vue
+++ b/studio-frontend/src/components/ModalCreateToken.vue
@@ -11,17 +11,62 @@
       </template>
     </FormInput>
     <DurationInput :field="expiration" v-model="expiration.value" />
+
+    <FormInput :field="avatar">
+      <template #custom-input="slotProps">
+        <div class="avatar-upload">
+          <input
+            type="file"
+            class="hidden"
+            ref="avatarFile"
+            :id="slotProps.id"
+            :accept="acceptedAvatarTypes"
+            @change="handleAvatarSelect" />
+          <div class="avatar-upload__row">
+            <Avatar
+              size="lg"
+              color="#dadada"
+              :src="avatarPreview"
+              :text="avatarPreview ? '' : '?'" />
+            <div class="avatar-upload__actions">
+              <label
+                :for="slotProps.id"
+                class="btn btn--secondary btn--sm">
+                <span class="label">{{ avatarUploadLabel }}</span>
+              </label>
+              <Button
+                v-if="avatar.value"
+                type="button"
+                variant="tertiary"
+                size="sm"
+                icon="x"
+                :label="$t('api_tokens_settings.modal_create.avatar_remove')"
+                @click="resetAvatar" />
+            </div>
+          </div>
+        </div>
+      </template>
+    </FormInput>
   </Modal>
 </template>
 <script>
-import { bus } from "@/main.js"
 import Modal from "@/components/molecules/Modal.vue"
 import FormInput from "@/components/molecules/FormInput.vue"
 import EMPTY_FIELD from "@/const/emptyField"
 import OrgaRoleSelector from "./molecules/OrgaRoleSelector.vue"
-import { apiCreateToken } from "@/api/token.js"
-import { mapGetters } from "vuex"
+import { apiCreateToken, apiUpdateTokenPicture } from "@/api/token.js"
 import DurationInput from "@/components/molecules/DurationInput.vue"
+import Avatar from "@/components/atoms/Avatar.vue"
+import Button from "@/components/atoms/Button.vue"
+
+const ACCEPTED_AVATAR_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/bmp",
+  "image/webp",
+]
+const MAX_AVATAR_SIZE = 5 * 1024 * 1024 // 5 MB
 
 export default {
   props: {
@@ -50,10 +95,51 @@ export default {
           min: 1,
         },
       },
+      avatar: {
+        ...EMPTY_FIELD,
+        label: this.$t("api_tokens_settings.modal_create.avatar_label"),
+        value: null,
+      },
+      avatarPreview: null,
     }
   },
-  mounted() {},
   methods: {
+    clearAvatarPreview() {
+      if (this.avatarPreview) URL.revokeObjectURL(this.avatarPreview)
+      this.avatarPreview = null
+    },
+    setAvatarError(messageKey) {
+      this.avatar.value = null
+      this.avatar.error = this.$t(messageKey)
+      this.clearAvatarPreview()
+    },
+    resetAvatar() {
+      this.avatar.value = null
+      this.avatar.error = null
+      this.clearAvatarPreview()
+      if (this.$refs.avatarFile) this.$refs.avatarFile.value = ""
+    },
+    handleAvatarSelect() {
+      const file = this.$refs.avatarFile?.files?.[0] ?? null
+      if (!file) {
+        this.resetAvatar()
+        return
+      }
+      if (!ACCEPTED_AVATAR_TYPES.includes(file.type)) {
+        this.setAvatarError(
+          "api_tokens_settings.modal_create.avatar_invalid_type",
+        )
+        return
+      }
+      if (file.size > MAX_AVATAR_SIZE) {
+        this.setAvatarError("api_tokens_settings.modal_create.avatar_too_large")
+        return
+      }
+      this.clearAvatarPreview()
+      this.avatar.value = file
+      this.avatar.error = null
+      this.avatarPreview = URL.createObjectURL(file)
+    },
     async createToken() {
       const expiration = this.expiration.value
       const req = await apiCreateToken(this.organizationId, {
@@ -63,12 +149,34 @@ export default {
       })
 
       if (req.status == "success") {
+        // Upload the avatar (best effort): the token has been created
+        // successfully even if this step fails, so we don't surface the
+        // error as a token-creation failure.
+        if (this.avatar.value && req.data?.user_id) {
+          try {
+            await apiUpdateTokenPicture(
+              this.organizationId,
+              req.data.user_id,
+              this.avatar.value,
+            )
+          } catch (err) {
+            this.$store.dispatch("system/addNotification", {
+              message: this.$t(
+                "api_tokens_settings.modal_create.avatar_upload_failed",
+              ),
+              type: "error",
+              timeout: 5000,
+            })
+          }
+        }
+
         this.$store.dispatch("system/addNotification", {
           message: this.$t("api_tokens_settings.token_created"),
           type: "success",
           timeout: 5000,
         })
-        this.$emit("handleTokenCreated", req.value)
+        this.resetAvatar()
+        this.$emit("handleTokenCreated", req.data)
       } else {
         this.$store.dispatch("system/addNotification", {
           message: this.$t("api_tokens_settings.token_created_error"),
@@ -87,12 +195,47 @@ export default {
         this.$emit("input", value)
       },
     },
+    avatarUploadLabel() {
+      return this.avatar.value
+        ? this.$t("api_tokens_settings.modal_create.avatar_change")
+        : this.$t("api_tokens_settings.modal_create.avatar_choose")
+    },
+    acceptedAvatarTypes() {
+      return ACCEPTED_AVATAR_TYPES.join(",")
+    },
   },
   components: {
     Modal,
     FormInput,
     OrgaRoleSelector,
     DurationInput,
+    Avatar,
+    Button,
   },
 }
 </script>
+
+<style scoped lang="scss">
+.hidden {
+  display: none;
+}
+.avatar-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+
+  &__row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/studio-frontend/src/locales/en-US.json
+++ b/studio-frontend/src/locales/en-US.json
@@ -79,7 +79,14 @@
     "token_expiring_soon": "Expiring soon",
     "modal_create": {
       "title": "Create a new key",
-      "expiration_label": "Validity duration"
+      "expiration_label": "Validity duration",
+      "avatar_label": "Avatar (optional)",
+      "avatar_choose": "Choose an image…",
+      "avatar_change": "Change image",
+      "avatar_remove": "Remove",
+      "avatar_invalid_type": "Invalid file type (only jpg, png, gif, bmp, webp)",
+      "avatar_too_large": "File too large (5 MB maximum)",
+      "avatar_upload_failed": "The API key was created but the avatar could not be uploaded"
     },
     "modal_delete": {
       "title": "Delete API token {name}",

--- a/studio-frontend/src/locales/fr-FR.json
+++ b/studio-frontend/src/locales/fr-FR.json
@@ -80,7 +80,14 @@
     "token_expiring_soon": "Expire bientôt",
     "modal_create": {
       "title": "Créer une clé d'API",
-      "expiration_label": "Durée de validité"
+      "expiration_label": "Durée de validité",
+      "avatar_label": "Avatar (optionnel)",
+      "avatar_choose": "Choisir une image…",
+      "avatar_change": "Changer l'image",
+      "avatar_remove": "Retirer",
+      "avatar_invalid_type": "Format invalide (jpg, png, gif, bmp, webp uniquement)",
+      "avatar_too_large": "Fichier trop volumineux (5 Mo maximum)",
+      "avatar_upload_failed": "La clé d'API a été créée mais l'avatar n'a pas pu être téléversé"
     },
     "modal_delete": {
       "title": "Supprimer la clé d'API '{name}'",

--- a/studio-frontend/src/store/organizations/actions.js
+++ b/studio-frontend/src/store/organizations/actions.js
@@ -60,12 +60,41 @@ const actions = {
 
     commit("setCurrentOrganization", organization)
     commit("setCurrentOrganizationScope", organizationId)
+    // Reset the M2M-augmented cache: it belongs to the previous org.
+    commit("setCurrentOrganizationAllUsers", [])
 
     // Clear selected tags when switching organizations
     await dispatch("tags/clearExploreSelectedTags", null, { root: true })
   },
   async setCurrentFilterStatus({ commit }, status) {
     commit("setCurrentFilterStatus", status)
+  },
+  /**
+   * Load the current organization with M2M users (API keys) included in
+   * the users array. Stored separately from currentOrganization to avoid
+   * leaking API keys into UIs that only want human members.
+   *
+   * Idempotent: subsequent calls reuse the cached value unless forceRefresh.
+   */
+  async loadCurrentOrganizationAllUsers(
+    { commit, state },
+    { forceRefresh = false } = {},
+  ) {
+    const organizationId = state.currentOrganizationScope
+    if (!organizationId) return []
+    if (
+      !forceRefresh &&
+      state.currentOrganizationAllUsers &&
+      state.currentOrganizationAllUsers.length > 0
+    ) {
+      return state.currentOrganizationAllUsers
+    }
+    const organization = await apiGetOrganizationById(organizationId, null, {
+      includeM2m: true,
+    })
+    const users = organization?.users ?? []
+    commit("setCurrentOrganizationAllUsers", users)
+    return users
   },
 }
 

--- a/studio-frontend/src/store/organizations/getters.js
+++ b/studio-frontend/src/store/organizations/getters.js
@@ -42,6 +42,13 @@ const getters = {
   getCurrentOrganizationUsers(state) {
     return state.currentOrganization?.users ?? []
   },
+  // Members + M2M (API keys). Populated lazily by
+  // `loadCurrentOrganizationAllUsers`. Use this getter for owner lookups
+  // (a media owner can be an API key). Do NOT use it for member listings
+  // or invitation pickers — `getCurrentOrganizationUsers` excludes M2M.
+  getCurrentOrganizationAllUsers(state) {
+    return state.currentOrganizationAllUsers ?? []
+  },
   getUserRoleInOrganization: (state, getters, rootState, rootGetters) => {
     let organization = getters.getCurrentOrganization
     const userId = rootGetters["user/getUserId"]

--- a/studio-frontend/src/store/organizations/mutations.js
+++ b/studio-frontend/src/store/organizations/mutations.js
@@ -18,6 +18,9 @@ const mutations = {
   setCurrentOrganization(state, organization) {
     state.currentOrganization = organization
   },
+  setCurrentOrganizationAllUsers(state, users) {
+    state.currentOrganizationAllUsers = Array.isArray(users) ? users : []
+  },
   deleteOrganization(state, id) {
     delete state.organizations[id]
     state.rolesInOrganizations.delete(id)

--- a/studio-frontend/src/store/organizations/state.js
+++ b/studio-frontend/src/store/organizations/state.js
@@ -5,6 +5,11 @@ const state = {
   currentOrganization: null,
   currentScope: null, // "organization" or "favorites" or "shared"
   currentFilterStatus: "done", // done, processing, error
+  // Full member list including M2M users (API keys). Loaded lazily when a
+  // consumer needs to resolve a media/conversation owner that may be an
+  // API key. Kept separate from currentOrganization.users so that human
+  // member listings (pickers, invitation UIs) stay unaffected.
+  currentOrganizationAllUsers: [],
 }
 
 export default state

--- a/studio-frontend/src/views/ConversationsOverview.vue
+++ b/studio-frontend/src/views/ConversationsOverview.vue
@@ -110,7 +110,12 @@ export default {
       loadingAudio: false,
     }
   },
-  mounted() {},
+  mounted() {
+    // Make sure the M2M-augmented user list is available so the owner of a
+    // conversation created by an API key renders with its real name and
+    // avatar.
+    this.$store.dispatch("organizations/loadCurrentOrganizationAllUsers")
+  },
   watch: {
     dataLoaded(data) {
       if (data) {


### PR DESCRIPTION
## Summary

This PR bundles two paired features (the second was previously #322, now consolidated here for review):

1. **Avatar upload for API keys** — attach an optional picture to an API key at creation time.
2. **M2M owner resolution** — make media/conversations owned by an API key resolve to their real name and avatar in the media explorer instead of the generic "Private user" fallback.

API keys are stored as M2M users that own every media or conversation they create. Without these two changes they show up anonymously with the default picture and the raw key name.

---

## Commit 1 — Avatar upload for API keys

### Backend (studio-api)
- New endpoint `PUT /organizations/:orgId/tokens/:tokenId/picture`, guarded by `requireOrganizationAdminAccess`. Multipart upload on field `file`, MIME validated (jpeg/png/gif/bmp/webp), reuses `storeFile()`, deletes the previous custom picture (never `defaultPicture()`), updates the M2M user `img`.
- `listApiKey()` projection exposes `img`.
- `deleteApiKey()` removes the key's custom picture from disk.

### Frontend (studio-frontend)
- `apiUpdateTokenPicture` wrapper.
- `ModalCreateToken`: optional picker with live preview (`createObjectURL`), MIME + size validation (5 MB). On submit the token is created first, then the picture is uploaded best-effort.
- `ApiTokenTable`: avatar shown next to the key name, initial fallback.
- i18n labels (fr-FR / en-US).

## Commit 2 — M2M owner resolution (formerly #322)

### Backend (studio-api)
- `GET /organizations/:id` accepts an opt-in `?includeM2m=true`. Default behaviour is unchanged (M2M filtered out) so member/sharing pickers and external API consumers are not affected.

### Frontend (studio-frontend)
- New `currentOrganizationAllUsers` Vuex slice + `getCurrentOrganizationAllUsers` getter + `loadCurrentOrganizationAllUsers` action (lazy, reset on org switch). Consulted only by owner-resolution paths so API keys never leak into member/invitation pickers.
- `MediaExplorerItem` (+ mobile), `ConversationOverviewRights` look the owner up in the augmented list first, falling back to the human list.

---

## Test plan

- [x] Upload jpeg/png/gif/bmp/webp at key creation → token + avatar in table.
- [x] Skip picker → unchanged behaviour, initial fallback.
- [x] Unsupported MIME / >5 MB → modal error label, no upload.
- [x] Replace existing picture → previous file deleted, new one stored.
- [x] Delete API key → custom picture removed, default picture untouched.
- [x] Media created by an API key → resolves to the key name + avatar in the media explorer (no "Private user").
- [x] Member / sharing / folder-access pickers → API keys not listed.