### PR TITLE
fix(studio-frontend): always show Live transcriptions menu when sessions feature is enabled

### DIFF
--- a/studio-frontend/src/api/session.js
+++ b/studio-frontend/src/api/session.js
@@ -294,23 +294,6 @@ export async function apiGetSessionsPaginated(
   return { list: [], count: 0, pageSize }
 }
 
-export async function apiHasSessions(organizationScope) {
-  try {
-    const res = await sendRequest(
-      `${BASE_API}/organizations/${organizationScope}/sessions`,
-      { method: "get" },
-      {
-        limit: 1,
-        organizationId: organizationScope,
-        excludeVisibility: "user",
-      },
-    )
-    return (res?.data?.totalItems ?? 0) > 0
-  } catch {
-    return false
-  }
-}
-
 export async function apiCountActiveSessions(organizationScope, notif) {
   const getStartedSessions = await sendRequest(
     `${BASE_API}/organizations/${organizationScope}/sessions`,

--- a/studio-frontend/src/components/MediaExplorerMenu.vue
+++ b/studio-frontend/src/components/MediaExplorerMenu.vue
@@ -29,7 +29,7 @@
           @select="handleInboxClick"
           @drop-media="handleInboxDrop" />
         <FolderTreeNode
-          v-if="hasSessions"
+          v-if="sessionEnable"
           :folder="sessionsFolder"
           :virtual="true"
           icon="broadcast"
@@ -77,10 +77,10 @@
 </template>
 
 <script>
-import { apiHasSessions } from "@/api/session.js"
 import { mediaScopeMixin } from "@/mixins/mediaScope"
 import { orgaRoleMixin } from "@/mixins/orgaRole.js"
 import { orgDisplayName } from "@/tools/orgDisplayName"
+import { getEnv } from "@/tools/getEnv"
 import FolderTree from "@/components/FolderTree.vue"
 import FolderTreeNode from "@/components/FolderTreeNode.vue"
 import ModalSwitchOrg from "@/components/ModalSwitchOrg.vue"
@@ -97,11 +97,13 @@ export default {
   },
   data() {
     return {
-      hasSessions: false,
       modalOrgSelector: false,
     }
   },
   computed: {
+    sessionEnable() {
+      return getEnv("VUE_APP_ENABLE_SESSION") === "true"
+    },
     currentOrganization() {
       return this.$store.getters["organizations/getCurrentOrganization"]
     },
@@ -169,15 +171,9 @@ export default {
   watch: {
     getCurrentOrganizationScope: {
       immediate: true,
-      async handler(orgId, oldOrgId) {
-        if (orgId) {
-          this.hasSessions = await apiHasSessions(orgId)
-          this.$store.dispatch(
-            `${orgId}/processing/conversations/loadStatusCount`,
-          )
-        } else {
-          this.hasSessions = false
-        }
+      handler(orgId) {
+        if (!orgId) return
+        this.$store.dispatch(`${orgId}/processing/conversations/loadStatusCount`)
       },
     },
   },


### PR DESCRIPTION
## Problem

The **"Live transcriptions"** navigation item in the sidebar disappeared entirely when an organization had **no sessions** (`apiHasSessions` returned `false`). As a result, a new user or a fresh organization could not reach the sessions page to create their **first** session — the only navigation entry point was hidden (leaving only direct-URL access).

## Root cause

The sessions `<FolderTreeNode>` was gated on `v-if="hasSessions"`, backed by an `apiHasSessions(orgId)` API call ("does the org already have ≥1 session?"). This **data-driven** signal conflated two distinct concerns:
- *Is the sessions feature deployed?* → a **deploy-time flag** (`VUE_APP_ENABLE_SESSION`)
- *Does the org already have sessions?* → **runtime data**

`MediaExplorerMenu.vue` was the **only** component using data-driven gating, while everywhere else (router guard `app-router.js`, `BurgerMenu.vue`, `ConversationsCreate.vue`) sessions access is gated by the **feature flag**.

## Fix

- Gate on `v-if="sessionEnable"` with `sessionEnable = getEnv("VUE_APP_ENABLE_SESSION") === "true"`, consistent with the router guard (which 404s `sessionPage` routes when the flag is off) and with `BurgerMenu.vue`.
- Remove the now-dead code: the `hasSessions` data property, the `apiHasSessions(orgId)` network call in the watcher, and the `apiHasSessions` function itself (no remaining callers in the repo).
- Clean up the watcher (dropped `async`, removed the unused `oldOrgId` param, guard clause). The `loadStatusCount` dispatch (processing counter, `immediate: true`) is preserved.

Beneficial side effect: menu visibility no longer depends on a network call at mount time.

## Testing

- `docker compose build studio-frontend` + recreate, full E-Meeting stack.
- Super admin login → created a **fresh organization (0 sessions)** → the "Live transcriptions" item is now **present** and leads to the sessions list (creating the first session works).
- With `VUE_APP_ENABLE_SESSION=false`, the item disappears (consistent with the router guard).

## Files

- `studio-frontend/src/components/MediaExplorerMenu.vue`
- `studio-frontend/src/api/session.js`