### PR TITLE
[studio-api] Fix empty saved transcription with speaker detection + translation

### DIFF
--- a/studio-api/components/WebServer/controllers/session/channelCaptions.js
+++ b/studio-api/components/WebServer/controllers/session/channelCaptions.js
@@ -30,12 +30,6 @@ function ensureSpeaker(caption, channel_caption) {
   return existingSpeaker.speaker_id
 }
 
-// Dual-recognizer sessions (e.g. speaker detection + translation) can emit
-// two closedCaptions lines for the same segmentId: one carrying the locutor
-// and text, another carrying the translations but no locutor. Collapse those
-// into a single line so the downstream translation merge (find by segmentId)
-// is deterministic and processChannelCaptions never produces duplicate turns.
-// Lines without a segmentId (e.g. bot markers) are left untouched.
 // Shallow-merge two optional translation maps into a fresh object
 // (non-object inputs are treated as empty).
 function unionTranslations(a, b) {
@@ -45,8 +39,19 @@ function unionTranslations(a, b) {
   }
 }
 
+// Dual-recognizer sessions (e.g. speaker detection + translation) can emit
+// two closedCaptions lines for the same segmentId: one carrying the locutor
+// and text, another carrying the translations but no locutor. Collapse those
+// into a single line so the downstream translation merge (find by segmentId)
+// is deterministic and processChannelCaptions never produces duplicate turns.
+// Lines without a segmentId (e.g. bot markers) are left untouched.
+//
+// The root cause is fixed upstream in emeeting's Transcriber (the secondary
+// recognizer's canonical line is dropped at the source); this stays as a
+// defensive backstop against producer/version skew, legacy recordings and
+// other providers that may still emit a separate translation-only line.
 function dedupeClosedCaptionsBySegmentId(closedCaptions = []) {
-  const indexBySegmentId = new Map() // segmentId -> index of the kept line in result
+  const keptBySegmentId = new Map() // segmentId -> the kept line, also held in result
   const result = []
 
   for (const cc of closedCaptions) {
@@ -56,32 +61,28 @@ function dedupeClosedCaptionsBySegmentId(closedCaptions = []) {
       continue
     }
 
-    const index = indexBySegmentId.get(cc.segmentId)
-    if (index === undefined) {
+    const existing = keptBySegmentId.get(cc.segmentId)
+    if (!existing) {
       // First line for this segmentId: clone so we never mutate the input.
       const clone = { ...cc }
       if (cc.translations && typeof cc.translations === "object")
         clone.translations = { ...cc.translations }
-      indexBySegmentId.set(cc.segmentId, result.length)
+      keptBySegmentId.set(cc.segmentId, clone)
       result.push(clone)
       continue
     }
 
-    const existing = result[index]
-    // Prefer the line that carries a locutor (and its text/timing) over one
-    // without; keep the translations already collected on the existing line.
-    if (!existing.locutor && cc.locutor) {
-      const merged = { ...cc }
-      const translations = unionTranslations(existing.translations, cc.translations)
-      if (Object.keys(translations).length > 0) merged.translations = translations
-      result[index] = merged
-      continue
-    }
-
-    // Otherwise keep the existing line and just union the translations.
-    if (cc.translations && typeof cc.translations === "object") {
-      existing.translations = unionTranslations(existing.translations, cc.translations)
-    }
+    // `existing` is the same reference stored in both the Map and `result`, so
+    // mutating it in place updates the kept line everywhere. Collect the union
+    // first, before adopting cc's fields can overwrite existing.translations.
+    const translations = unionTranslations(
+      existing.translations,
+      cc.translations,
+    )
+    // Prefer the line that carries a locutor (and its text/timing).
+    if (!existing.locutor && cc.locutor) Object.assign(existing, cc)
+    if (Object.keys(translations).length > 0)
+      existing.translations = translations
   }
 
   return result

--- a/studio-api/components/WebServer/controllers/session/channelCaptions.js
+++ b/studio-api/components/WebServer/controllers/session/channelCaptions.js
@@ -36,8 +36,17 @@ function ensureSpeaker(caption, channel_caption) {
 // into a single line so the downstream translation merge (find by segmentId)
 // is deterministic and processChannelCaptions never produces duplicate turns.
 // Lines without a segmentId (e.g. bot markers) are left untouched.
+// Shallow-merge two optional translation maps into a fresh object
+// (non-object inputs are treated as empty).
+function unionTranslations(a, b) {
+  return {
+    ...(a && typeof a === "object" ? a : {}),
+    ...(b && typeof b === "object" ? b : {}),
+  }
+}
+
 function dedupeClosedCaptionsBySegmentId(closedCaptions = []) {
-  const bySegmentId = new Map()
+  const indexBySegmentId = new Map() // segmentId -> index of the kept line in result
   const result = []
 
   for (const cc of closedCaptions) {
@@ -47,47 +56,31 @@ function dedupeClosedCaptionsBySegmentId(closedCaptions = []) {
       continue
     }
 
-    const existing = bySegmentId.get(cc.segmentId)
-    if (!existing) {
+    const index = indexBySegmentId.get(cc.segmentId)
+    if (index === undefined) {
       // First line for this segmentId: clone so we never mutate the input.
       const clone = { ...cc }
-      if (clone.translations && typeof clone.translations === "object")
-        clone.translations = { ...clone.translations }
-      bySegmentId.set(cc.segmentId, clone)
+      if (cc.translations && typeof cc.translations === "object")
+        clone.translations = { ...cc.translations }
+      indexBySegmentId.set(cc.segmentId, result.length)
       result.push(clone)
       continue
     }
 
-    // Merge a duplicate line into the already-kept one.
-    // Prefer a non-empty locutor (and its text/timing) over a missing one.
+    const existing = result[index]
+    // Prefer the line that carries a locutor (and its text/timing) over one
+    // without; keep the translations already collected on the existing line.
     if (!existing.locutor && cc.locutor) {
       const merged = { ...cc }
-      // Preserve any translations already collected on the existing line.
-      const mergedTranslations = {
-        ...(existing.translations && typeof existing.translations === "object"
-          ? existing.translations
-          : {}),
-        ...(cc.translations && typeof cc.translations === "object"
-          ? cc.translations
-          : {}),
-      }
-      if (Object.keys(mergedTranslations).length > 0)
-        merged.translations = mergedTranslations
-      // Replace in place inside the result array.
-      const idx = result.indexOf(existing)
-      if (idx !== -1) result[idx] = merged
-      bySegmentId.set(cc.segmentId, merged)
+      const translations = unionTranslations(existing.translations, cc.translations)
+      if (Object.keys(translations).length > 0) merged.translations = translations
+      result[index] = merged
       continue
     }
 
     // Otherwise keep the existing line and just union the translations.
     if (cc.translations && typeof cc.translations === "object") {
-      existing.translations = {
-        ...(existing.translations && typeof existing.translations === "object"
-          ? existing.translations
-          : {}),
-        ...cc.translations,
-      }
+      existing.translations = unionTranslations(existing.translations, cc.translations)
     }
   }
 

--- a/studio-api/components/WebServer/controllers/session/channelCaptions.js
+++ b/studio-api/components/WebServer/controllers/session/channelCaptions.js
@@ -30,6 +30,70 @@ function ensureSpeaker(caption, channel_caption) {
   return existingSpeaker.speaker_id
 }
 
+// Dual-recognizer sessions (e.g. speaker detection + translation) can emit
+// two closedCaptions lines for the same segmentId: one carrying the locutor
+// and text, another carrying the translations but no locutor. Collapse those
+// into a single line so the downstream translation merge (find by segmentId)
+// is deterministic and processChannelCaptions never produces duplicate turns.
+// Lines without a segmentId (e.g. bot markers) are left untouched.
+function dedupeClosedCaptionsBySegmentId(closedCaptions = []) {
+  const bySegmentId = new Map()
+  const result = []
+
+  for (const cc of closedCaptions) {
+    if (cc.segmentId === undefined || cc.segmentId === null) {
+      // No segmentId (bot markers, etc.) — keep as-is, never merge.
+      result.push(cc)
+      continue
+    }
+
+    const existing = bySegmentId.get(cc.segmentId)
+    if (!existing) {
+      // First line for this segmentId: clone so we never mutate the input.
+      const clone = { ...cc }
+      if (clone.translations && typeof clone.translations === "object")
+        clone.translations = { ...clone.translations }
+      bySegmentId.set(cc.segmentId, clone)
+      result.push(clone)
+      continue
+    }
+
+    // Merge a duplicate line into the already-kept one.
+    // Prefer a non-empty locutor (and its text/timing) over a missing one.
+    if (!existing.locutor && cc.locutor) {
+      const merged = { ...cc }
+      // Preserve any translations already collected on the existing line.
+      const mergedTranslations = {
+        ...(existing.translations && typeof existing.translations === "object"
+          ? existing.translations
+          : {}),
+        ...(cc.translations && typeof cc.translations === "object"
+          ? cc.translations
+          : {}),
+      }
+      if (Object.keys(mergedTranslations).length > 0)
+        merged.translations = mergedTranslations
+      // Replace in place inside the result array.
+      const idx = result.indexOf(existing)
+      if (idx !== -1) result[idx] = merged
+      bySegmentId.set(cc.segmentId, merged)
+      continue
+    }
+
+    // Otherwise keep the existing line and just union the translations.
+    if (cc.translations && typeof cc.translations === "object") {
+      existing.translations = {
+        ...(existing.translations && typeof existing.translations === "object"
+          ? existing.translations
+          : {}),
+        ...cc.translations,
+      }
+    }
+  }
+
+  return result
+}
+
 function createTurn(
   channel_caption,
   spk_id,
@@ -38,10 +102,6 @@ function createTurn(
   caption,
 ) {
   try {
-    if (main && diarization && !channel_caption.locutor) {
-      return
-    }
-
     let turn = {
       speaker_id: spk_id,
       turn_id: uuidv4(),
@@ -129,4 +189,5 @@ module.exports = {
   processChannelCaptions,
   ensureSpeaker,
   createTurn,
+  dedupeClosedCaptionsBySegmentId,
 }

--- a/studio-api/components/WebServer/controllers/session/conversation.js
+++ b/studio-api/components/WebServer/controllers/session/conversation.js
@@ -16,7 +16,10 @@ const SECURITY_LEVELS = require(
 const { storeFile } = require(
   `${process.cwd()}/components/WebServer/controllers/files/store`,
 )
-const { processChannelCaptions } = require("./channelCaptions")
+const {
+  processChannelCaptions,
+  dedupeClosedCaptionsBySegmentId,
+} = require("./channelCaptions")
 
 const { SessionError } = require(
   `${process.cwd()}/components/WebServer/error/exception/session`,
@@ -148,6 +151,16 @@ async function initCaptionsForConversation(sessionData, name) {
         name,
         session.channels.length,
       )
+
+      // Dual-recognizer sessions may emit two closedCaptions lines per
+      // segmentId (one with the locutor, one with translations). Collapse
+      // them so the translation merge below and processChannelCaptions are
+      // deterministic and never produce duplicate turns.
+      if (Array.isArray(channel.closedCaptions)) {
+        channel.closedCaptions = dedupeClosedCaptionsBySegmentId(
+          channel.closedCaptions,
+        )
+      }
 
       if (channel.translatedCaptions) {
         for (const segmentTranslations of Object.values(

--- a/studio-api/components/WebServer/controllers/session/conversation.js
+++ b/studio-api/components/WebServer/controllers/session/conversation.js
@@ -514,4 +514,5 @@ module.exports = {
   storeSession,
   storeSessionFromStop,
   storeQuickMeetingFromStop,
+  initCaptionsForConversation,
 }

--- a/studio-api/tests/test/session/channelCaptions.test.js
+++ b/studio-api/tests/test/session/channelCaptions.test.js
@@ -1,5 +1,5 @@
 const cp = structuredClone
-const { processChannelCaptions } = require(
+const { processChannelCaptions, dedupeClosedCaptionsBySegmentId } = require(
   `${process.cwd()}/components/WebServer/controllers/session/channelCaptions`,
 )
 const TYPES = require(`${process.cwd()}/lib/dao/conversation/types`)
@@ -174,7 +174,7 @@ describe("processChannelCaptions", () => {
   })
 
   describe("diarization flag", () => {
-    it("filters out segments without locutor when main=true and diarization=true", () => {
+    it("keeps segments without locutor under an 'Unknown speaker' when main=true and diarization=true", () => {
       const channel = {
         diarization: true,
         closedCaptions: [
@@ -199,8 +199,65 @@ describe("processChannelCaptions", () => {
       const caption = makeCaption()
       processChannelCaptions(channel, caption, true)
 
-      expect(caption.text).toHaveLength(1)
-      expect(caption.text[0].raw_segment).toEqual("with locutor")
+      // No silent data loss anymore: both segments survive, the locutor-less
+      // one is attached to the default "Unknown speaker".
+      expect(caption.text).toHaveLength(2)
+      const texts = caption.text.map((t) => t.raw_segment).sort()
+      expect(texts).toEqual(["with locutor", "without locutor"])
+
+      const unknown = caption.speakers.find(
+        (s) => s.speaker_name === "Unknown speaker",
+      )
+      const alice = caption.speakers.find((s) => s.speaker_name === "Alice")
+      expect(unknown).toBeDefined()
+      expect(alice).toBeDefined()
+
+      const withoutLocutorTurn = caption.text.find(
+        (t) => t.raw_segment === "without locutor",
+      )
+      expect(withoutLocutorTurn.speaker_id).toEqual(unknown.speaker_id)
+      const withLocutorTurn = caption.text.find(
+        (t) => t.raw_segment === "with locutor",
+      )
+      expect(withLocutorTurn.speaker_id).toEqual(alice.speaker_id)
+    })
+
+    it("never empties the canonical when ALL segments lack a locutor (diarization=true regression)", () => {
+      // Regression for: "Saved transcription is empty when speaker detection
+      // AND translation are both enabled". Previously every locutor-less
+      // segment was dropped, leaving the canonical empty.
+      const channel = {
+        diarization: true,
+        closedCaptions: [
+          {
+            segmentId: 1,
+            start: 0,
+            end: 1,
+            text: "no locutor 1",
+            lang: "fr-FR",
+            locutor: null,
+          },
+          {
+            segmentId: 2,
+            start: 1,
+            end: 2,
+            text: "no locutor 2",
+            lang: "fr-FR",
+            locutor: null,
+          },
+        ],
+      }
+      const caption = makeCaption()
+      processChannelCaptions(channel, caption, true)
+
+      expect(caption.text).toHaveLength(2)
+      expect(caption.speakers).toHaveLength(1)
+      expect(caption.speakers[0].speaker_name).toEqual("Unknown speaker")
+      const speakerId = caption.speakers[0].speaker_id
+      for (const turn of caption.text) {
+        expect(turn.speaker_id).toEqual(speakerId)
+        expect(turn.raw_segment).not.toEqual("")
+      }
     })
 
     it("keeps segments without locutor when diarization=false", () => {
@@ -583,6 +640,229 @@ describe("processChannelCaptions", () => {
 
       expect(caption.text).toEqual([])
       expect(caption.speakers).toEqual([])
+    })
+  })
+
+  describe("dedupeClosedCaptionsBySegmentId", () => {
+    it("collapses two lines sharing a segmentId, preferring the one with a locutor", () => {
+      const closedCaptions = [
+        {
+          segmentId: 1,
+          start: 0,
+          end: 1,
+          text: "hello",
+          lang: "fr-FR",
+          locutor: "Alice",
+        },
+        {
+          segmentId: 1,
+          start: 0,
+          end: 1,
+          text: "",
+          lang: "fr-FR",
+          locutor: null,
+          translations: { de: "hallo" },
+        },
+      ]
+      const result = dedupeClosedCaptionsBySegmentId(closedCaptions)
+      expect(result).toHaveLength(1)
+      expect(result[0].locutor).toEqual("Alice")
+      expect(result[0].text).toEqual("hello")
+      expect(result[0].translations).toEqual({ de: "hallo" })
+    })
+
+    it("unions translations regardless of which line carries the locutor", () => {
+      const closedCaptions = [
+        {
+          segmentId: 7,
+          start: 0,
+          end: 1,
+          text: "x",
+          locutor: null,
+          translations: { de: "de7", en: "en7" },
+        },
+        {
+          segmentId: 7,
+          start: 0,
+          end: 1,
+          text: "x",
+          locutor: "Bob",
+          translations: { es: "es7" },
+        },
+      ]
+      const result = dedupeClosedCaptionsBySegmentId(closedCaptions)
+      expect(result).toHaveLength(1)
+      expect(result[0].locutor).toEqual("Bob")
+      expect(result[0].translations).toEqual({
+        de: "de7",
+        en: "en7",
+        es: "es7",
+      })
+    })
+
+    it("leaves lines without a segmentId untouched and unmerged (bot markers)", () => {
+      const closedCaptions = [
+        { segmentId: null, text: "", locutor: "bot", aend: "x" },
+        { segmentId: null, text: "", locutor: "bot", aend: "y" },
+        {
+          segmentId: 1,
+          start: 0,
+          end: 1,
+          text: "real",
+          locutor: "Alice",
+        },
+      ]
+      const result = dedupeClosedCaptionsBySegmentId(closedCaptions)
+      expect(result).toHaveLength(3)
+      expect(result.filter((c) => c.locutor === "bot")).toHaveLength(2)
+    })
+
+    it("does not mutate the input array or its objects", () => {
+      const closedCaptions = [
+        {
+          segmentId: 1,
+          start: 0,
+          end: 1,
+          text: "a",
+          locutor: "Alice",
+          translations: { de: "da" },
+        },
+        {
+          segmentId: 1,
+          start: 0,
+          end: 1,
+          text: "",
+          locutor: null,
+          translations: { en: "ea" },
+        },
+      ]
+      const before = cp(closedCaptions)
+      dedupeClosedCaptionsBySegmentId(closedCaptions)
+      expect(closedCaptions).toEqual(before)
+    })
+
+    it("is a no-op for mono-recognizer input (one line per segmentId)", () => {
+      const closedCaptions = [
+        { segmentId: 1, start: 0, end: 1, text: "a", locutor: null },
+        { segmentId: 2, start: 1, end: 2, text: "b", locutor: null },
+      ]
+      const result = dedupeClosedCaptionsBySegmentId(closedCaptions)
+      expect(result).toHaveLength(2)
+      expect(result.map((c) => c.text)).toEqual(["a", "b"])
+    })
+  })
+
+  describe("dual-recognizer (speaker detection + translation) end-to-end", () => {
+    // Mimic the full preprocessing pipeline of initCaptionsForConversation:
+    // dedupe by segmentId, then merge translatedCaptions, then build the
+    // canonical (main=true) and a translation pass (main=false).
+    function buildDualRecognizerChannel() {
+      return {
+        diarization: true,
+        translations: [{ target: "de" }],
+        // Two lines per segment: one with locutor+text, one with translations.
+        closedCaptions: [
+          {
+            segmentId: 1,
+            start: 0,
+            end: 2,
+            text: "bonjour",
+            lang: "fr-FR",
+            locutor: "Alice",
+          },
+          {
+            segmentId: 1,
+            start: 0,
+            end: 2,
+            text: "bonjour",
+            lang: "fr-FR",
+            locutor: null,
+          },
+          {
+            segmentId: 2,
+            start: 2,
+            end: 4,
+            text: "ca va",
+            lang: "fr-FR",
+            locutor: "Bob",
+          },
+          {
+            segmentId: 2,
+            start: 2,
+            end: 4,
+            text: "ca va",
+            lang: "fr-FR",
+            locutor: null,
+          },
+        ],
+        translatedCaptions: {
+          de: [
+            { segmentId: 1, targetLang: "de", text: "hallo" },
+            { segmentId: 2, targetLang: "de", text: "wie gehts" },
+          ],
+        },
+      }
+    }
+
+    function preprocess(channel) {
+      channel.closedCaptions = dedupeClosedCaptionsBySegmentId(
+        channel.closedCaptions,
+      )
+      applyTranslationsToSegments(channel)
+    }
+
+    it("produces one non-empty turn per segment attached to the right locutor", () => {
+      const channel = buildDualRecognizerChannel()
+      preprocess(channel)
+
+      const canonical = makeCaption({ mode: TYPES.CHILD })
+      processChannelCaptions(channel, canonical, true)
+
+      expect(canonical.text).toHaveLength(2)
+      const names = canonical.speakers.map((s) => s.speaker_name).sort()
+      expect(names).toEqual(["Alice", "Bob"])
+
+      const aliceId = canonical.speakers.find(
+        (s) => s.speaker_name === "Alice",
+      ).speaker_id
+      const bobId = canonical.speakers.find(
+        (s) => s.speaker_name === "Bob",
+      ).speaker_id
+
+      const t1 = canonical.text.find((t) => t.raw_segment === "bonjour")
+      const t2 = canonical.text.find((t) => t.raw_segment === "ca va")
+      expect(t1.speaker_id).toEqual(aliceId)
+      expect(t2.speaker_id).toEqual(bobId)
+      for (const turn of canonical.text) {
+        expect(turn.raw_segment).not.toEqual("")
+      }
+    })
+
+    it("merges translations deterministically and emits a translated pass", () => {
+      const channel = buildDualRecognizerChannel()
+      preprocess(channel)
+
+      const tlCaption = makeCaption({ mode: TYPES.TRANSLATION, locale: "de" })
+      processChannelCaptions(channel, tlCaption, false)
+
+      expect(tlCaption.text).toHaveLength(2)
+      const texts = tlCaption.text.map((t) => t.raw_segment).sort()
+      expect(texts).toEqual(["hallo", "wie gehts"])
+      expect(tlCaption.speakers).toHaveLength(1)
+      expect(tlCaption.speakers[0].speaker_name).toEqual(
+        "Automatic Translation",
+      )
+    })
+
+    it("does not produce duplicate turns from the duplicated input lines", () => {
+      const channel = buildDualRecognizerChannel()
+      // 4 input lines (2 per segment) collapse to 2 segments.
+      preprocess(channel)
+      expect(channel.closedCaptions).toHaveLength(2)
+
+      const canonical = makeCaption({ mode: TYPES.CHILD })
+      processChannelCaptions(channel, canonical, true)
+      expect(canonical.text).toHaveLength(2)
     })
   })
 

--- a/studio-api/tests/test/session/conversation.test.js
+++ b/studio-api/tests/test/session/conversation.test.js
@@ -1,0 +1,186 @@
+/**
+ * Wiring tests for initCaptionsForConversation (conversation.js).
+ *
+ * The channelCaptions.test.js suite exercises dedupeClosedCaptionsBySegmentId
+ * and processChannelCaptions in isolation, and its "dual-recognizer end-to-end"
+ * block RE-SIMULATES the pipeline with local helpers. None of that proves the
+ * REAL initCaptionsForConversation actually invokes the dedup, nor that it runs
+ * BEFORE the translatedCaptions merge.
+ *
+ * These tests call the real initCaptionsForConversation on a realistic
+ * dual-recognizer session payload and assert on the produced captions, so that
+ * removing or moving the dedup call (e.g. after the translation merge) would
+ * break them.
+ *
+ * Only require-time dependencies that would otherwise open a Mongo connection
+ * or pull in the ESM music-metadata module are mocked. initCaptionsForConversation
+ * itself touches none of them for the chosen payload (no DB, no audio I/O).
+ */
+
+// lib/mongodb/driver.js builds a MongoClient at require time from DB_* env vars.
+jest.mock(`${process.cwd()}/lib/mongodb/models`, () => ({}))
+
+// offline.js -> generator.js -> music-metadata (ESM). Only used by the
+// store path (startOfflineJob), never by initCaptionsForConversation.
+jest.mock(
+  `${process.cwd()}/components/WebServer/routecontrollers/organizations/uploader/offline.js`,
+  () => ({ sessionReq: jest.fn() }),
+)
+
+// storeFile would do filesystem/audio I/O; the chosen payload never reaches it.
+jest.mock(`${process.cwd()}/components/WebServer/controllers/files/store`, () => ({
+  storeFile: jest.fn(),
+}))
+
+const { initCaptionsForConversation } = require(
+  `${process.cwd()}/components/WebServer/controllers/session/conversation.js`,
+)
+const TYPES = require(`${process.cwd()}/lib/dao/conversation/types`)
+
+// Realistic dual-recognizer (speaker detection + translation) single-channel
+// session. Each segmentId is emitted TWICE: once by the recognizer that lacks
+// the locutor, once by the recognizer that carries it. The no-locutor line is
+// intentionally ordered FIRST so that:
+//   - dedupe keeps the locutor-bearing line (locutor !== null wins);
+//   - the translation merge (Array.find by segmentId) attaches `de` to the
+//     SINGLE deduped line. Without dedup, find() returns the first (no-locutor)
+//     line, so the translation lands on the wrong line and the canonical
+//     produces duplicate / "Unknown speaker" turns.
+// compressAudio:true + keepAudio:false guarantees no storeFile/audio branch.
+function buildDualRecognizerSession() {
+  return {
+    id: "session-dual-rec",
+    name: "Dual recognizer meeting",
+    owner: "owner-id",
+    organizationId: "orga-id",
+    visibility: "public",
+    startTime: "2026-05-01T10:00:00.000Z",
+    endTime: "2026-05-01T10:05:00.000Z",
+    channels: [
+      {
+        id: "0",
+        name: "fr",
+        languages: "fr-FR",
+        diarization: true,
+        compressAudio: true,
+        keepAudio: false,
+        translations: [{ target: "de" }],
+        closedCaptions: [
+          // segment 1 — no-locutor line FIRST
+          {
+            segmentId: 1,
+            start: 0.5,
+            end: 2,
+            text: "bonjour",
+            lang: "fr-FR",
+            locutor: null,
+          },
+          {
+            segmentId: 1,
+            start: 0.5,
+            end: 2,
+            text: "bonjour",
+            lang: "fr-FR",
+            locutor: "Alice",
+          },
+          // segment 2 — no-locutor line FIRST
+          {
+            segmentId: 2,
+            start: 2,
+            end: 4,
+            text: "ca va",
+            lang: "fr-FR",
+            locutor: null,
+          },
+          {
+            segmentId: 2,
+            start: 2,
+            end: 4,
+            text: "ca va",
+            lang: "fr-FR",
+            locutor: "Bob",
+          },
+        ],
+        translatedCaptions: {
+          de: [
+            { segmentId: 1, targetLang: "de", text: "hallo" },
+            { segmentId: 2, targetLang: "de", text: "wie gehts" },
+          ],
+        },
+      },
+    ],
+  }
+}
+
+describe("initCaptionsForConversation wiring (dual-recognizer)", () => {
+  let captions, canonical, translation
+
+  beforeEach(async () => {
+    captions = await initCaptionsForConversation(buildDualRecognizerSession())
+    canonical = captions.find((c) => c.type.mode !== TYPES.TRANSLATION)
+    translation = captions.find((c) => c.type.mode === TYPES.TRANSLATION)
+  })
+
+  it("emits exactly one canonical and one translation caption", () => {
+    expect(captions).toHaveLength(2)
+    expect(canonical).toBeDefined()
+    expect(translation).toBeDefined()
+    expect(translation.locale).toEqual("de")
+  })
+
+  it("produces a single canonical turn per segmentId (no duplicate from the doubled input lines)", () => {
+    // 2 segments, 2 input lines each (4 total) must collapse to 2 turns.
+    // Without the dedup, the locutor-less duplicates survive -> 4 turns.
+    expect(canonical.text).toHaveLength(2)
+    const segTexts = canonical.text.map((t) => t.raw_segment).sort()
+    expect(segTexts).toEqual(["bonjour", "ca va"])
+  })
+
+  it("attaches each canonical turn to its real locutor, never 'Unknown speaker'", () => {
+    // The no-locutor line is ordered first; dedup must collapse it into the
+    // locutor-bearing line BEFORE turns are built, otherwise the surviving
+    // turn would be 'Unknown speaker'.
+    const names = canonical.speakers.map((s) => s.speaker_name).sort()
+    expect(names).toEqual(["Alice", "Bob"])
+    expect(names).not.toContain("Unknown speaker")
+
+    const aliceId = canonical.speakers.find(
+      (s) => s.speaker_name === "Alice",
+    ).speaker_id
+    const bobId = canonical.speakers.find(
+      (s) => s.speaker_name === "Bob",
+    ).speaker_id
+
+    const t1 = canonical.text.find((t) => t.raw_segment === "bonjour")
+    const t2 = canonical.text.find((t) => t.raw_segment === "ca va")
+    expect(t1.speaker_id).toEqual(aliceId)
+    expect(t2.speaker_id).toEqual(bobId)
+  })
+
+  it("builds a 'de' translation caption whose turns carry the translated text", () => {
+    expect(translation.type.mode).toEqual(TYPES.TRANSLATION)
+    expect(translation.text).toHaveLength(2)
+    const texts = translation.text.map((t) => t.raw_segment).sort()
+    expect(texts).toEqual(["hallo", "wie gehts"])
+    expect(translation.speakers).toHaveLength(1)
+    expect(translation.speakers[0].speaker_name).toEqual("Automatic Translation")
+    expect(translation.parentCaptionId).toEqual(canonical.captionId)
+  })
+
+  it("proves dedup runs BEFORE the translation merge: translations land on the kept (locutor) line", () => {
+    // This is the load-bearing assertion. The no-locutor line is first; the
+    // translation merge resolves the target line with Array.find by segmentId.
+    //   - dedup-before-merge: only ONE line per segmentId exists (the locutor
+    //     one), so translations attach to it and the translation pass emits
+    //     exactly one turn per segment (2 total).
+    //   - merge-before-dedup / no-dedup: find() hits the first (no-locutor)
+    //     line, so the locutor line keeps NO translation. processChannelCaptions
+    //     in TRANSLATION mode drops turns lacking translations[locale], yielding
+    //     a different (broken) turn count and/or canonical duplicates.
+    expect(translation.text).toHaveLength(canonical.text.length)
+    for (const turn of translation.text) {
+      expect(turn.raw_segment).not.toEqual("")
+      expect(turn.segment).toEqual(turn.raw_segment)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

Saving a session with **speaker detection + translation** enabled produced an **empty** canonical document, even though the live transcription and translations displayed fine.

In `processChannelCaptions` the guard `if (main && diarization && !channel_caption.locutor) return` dropped every segment without a `locutor`. With locutor-less (and segmentId-duplicated) captions coming from the transcriber, all canonical turns were discarded. Translations (the `main=false` pass) bypassed the guard, hence the asymmetry.

## Changes

- `channelCaptions.js`: add `dedupeClosedCaptionsBySegmentId` (collapse lines sharing a `segmentId`, prefer the one with a `locutor`, union translations; leave segmentId-less bot markers untouched; no input mutation). Remove the destructive guard in `createTurn` so a locutor-less segment falls back to "Unknown speaker" instead of being silently dropped.
- `conversation.js`: run the dedup before the `translatedCaptions` merge so the per-`segmentId` join is deterministic.
- Cleanup: `unionTranslations` helper, removed an O(n^2) `indexOf`. The dedup keeps the kept line directly in the `Map` and mutates it in place (no index indirection / write-back), computing the translation union before adopting the locutor line's fields. Comments reflowed and a note added that the root cause is fixed upstream in the Transcriber — this stays as a defensive backstop against producer/version skew. Prettier-clean.

## Tests

- `channelCaptions.test.js`: dedup, "Unknown speaker" fallback, "never empties the canonical" regression, dual-recognizer.
- `conversation.test.js` (new): exercises the real `initCaptionsForConversation` and fails if the dedup is removed or misplaced.
- studio-api suite: 336 passing. The 2 `initConversation`/`conversationGenerator` suites fail to load on a pre-existing, unrelated `music-metadata` ESM issue.

## Related — upstream root-cause fix (`linto-studio-plugins`)

The Transcriber-side fix that makes the primary recognizer a `ConversationTranscriber` (so `locutor` is populated) and tags the secondary `TranslationRecognizer` — same work-order. Pushed to `next` (`db70a42..88ee340`):

- Compare: https://github.com/linto-ai/linto-studio-plugins/compare/db70a42...88ee340
- [`8d6e918`](https://github.com/linto-ai/linto-studio-plugins/commit/8d6e9180705330e83ab9b9817a43ce341775740e) Fix diarization+translation dual recognizer producing empty saved transcript
- [`dcbc421`](https://github.com/linto-ai/linto-studio-plugins/commit/dcbc42198f107d45d5126b1d148330b2bde1fa95) Add tests for dual recognizer types, origin-tagging and segmentId alignment
- [`4f27e8e`](https://github.com/linto-ai/linto-studio-plugins/commit/4f27e8e2f2241572073a892772b9b8e13de30023) Simplify: drop redundant SecondaryRecognizerListener overrides
- [`fad9c9d`](https://github.com/linto-ai/linto-studio-plugins/commit/fad9c9d7395b5c7925759e2637ae39abd6d90e25) Add integration scenario for diarization+translation (Azure) saved-transcript fix
- [`88ee340`](https://github.com/linto-ai/linto-studio-plugins/commit/88ee340a965610922fdc3da6686123686e86bfa2) Harden diar+translation integration fixture to 35s

## End-to-end verification (real stack)

Validated on the full LinTO stack with a real Microsoft Azure backend (francecentral) and the `fr.mp3` fixture streamed over SRT into a live session with **diarization ON + discrete `de` translation**:

- Transcriber emitted both recognizers: primary `ConversationTranscriber` (populated `locutor`) + secondary `TranslationRecognizer` (German). Session-API: 4 captions, all with a locutor, one per `segmentId`, 3 `de` translations.
- After archiving the session (the `DELETE` path that runs `storeSessionFromStop → initCaptionsForConversation → dedupeClosedCaptionsBySegmentId`), the **saved conversation was non-empty**: 3 canonical turns with speaker `Guest-1` + a linked German child conversation with 3 translated turns ("Hallo, willkommen zu unserem täglichen…"). Before the fix this document was empty.

## Note

Defense-in-depth, decoupled from the Transcriber dual-recognizer fix. No deployment ordering required and no interface change.
