### PR TITLE
[studio-api] Stop session via waitFinal drain barrier before conversion

### DIFF
--- a/studio-api/.envdefault
+++ b/studio-api/.envdefault
@@ -91,6 +91,9 @@ SUPER_ADMIN_PWD=
 # Bellow are the settings require for the session service
 SESSION_API_ENDPOINT=
 SESSION_PSW_SALT=secret_salt
+# Max time studio-api waits for the stop drain barrier (keep above the
+# Session API's SESSION_STOP_FLUSH_TIMEOUT_MS, 10s)
+SESSION_STOP_TIMEOUT_MS=15000
 
 # Socket.IO Redis Adapter (optional, for multi-instance scaling)
 # Leave SOCKETIO_REDIS_HOST empty to use default in-memory adapter

--- a/studio-api/components/WebServer/controllers/session/conversation.js
+++ b/studio-api/components/WebServer/controllers/session/conversation.js
@@ -1,6 +1,7 @@
 const debug = require("debug")(
   `linto:components:WebServer:controllers:session:conversation`,
 )
+const logger = require(`${process.cwd()}/lib/logger/logger`)
 
 const axios = require(`${process.cwd()}/lib/utility/axios`)
 
@@ -294,7 +295,12 @@ async function storeSession(session, name = undefined) {
     let conversationMemory = []
     const { canonicalCount, translationCount } = countCaptions(captions)
 
-    if (canonicalCount === 0) return
+    if (canonicalCount === 0) {
+      logger.warn(
+        `storeSession: session ${session.id} has no canonical captions after filtering — nothing stored`,
+      )
+      return
+    }
 
     const result =
       canonicalCount === 1
@@ -456,19 +462,57 @@ async function storeProxyResponse(session) {
   }
 }
 
-async function storeSessionFromStop(req, next) {
-  try {
-    const session = await axios.get(
-      process.env.SESSION_API_ENDPOINT + `/sessions/${req.params.id}`,
-    )
-    let result = await storeSession(session, req.query.name)
+const SESSION_STOP_TIMEOUT_MS =
+  parseInt(process.env.SESSION_STOP_TIMEOUT_MS, 10) || 15000
 
-    if (this.app.components.IoHandler !== undefined) {
-      this.app.components.IoHandler.emit("new_conversation_from_session", {
+// Stop (waitFinal drain barrier) before reading, so the GET sees every
+// committed caption. Older Session APIs ignore waitFinal — never worse.
+async function stopSessionAndFetch(sessionId) {
+  try {
+    await axios.put(
+      process.env.SESSION_API_ENDPOINT +
+        `/sessions/${sessionId}/stop?force=true&waitFinal=true`,
+      {},
+      { timeout: SESSION_STOP_TIMEOUT_MS },
+    )
+  } catch (err) {
+    logger.warn(
+      `stopSessionAndFetch: stop failed for session ${sessionId}, reading as-is: ${err?.message || err}`,
+    )
+  }
+  return await axios.get(
+    process.env.SESSION_API_ENDPOINT + `/sessions/${sessionId}`,
+  )
+}
+
+// Emit the new-conversation event, or warn when nothing was stored.
+function emitConversationFromSession(ioHandler, session, result, sessionId, label) {
+  if (result) {
+    if (ioHandler !== undefined) {
+      ioHandler.emit("new_conversation_from_session", {
         organizationId: session.organizationId,
         ...result,
       })
     }
+  } else {
+    logger.warn(
+      `${label} ${sessionId} stopped with no storable captions — no conversation created`,
+    )
+  }
+}
+
+async function storeSessionFromStop(req, next) {
+  try {
+    const session = await stopSessionAndFetch(req.params.id)
+    let result = await storeSession(session, req.query.name)
+
+    emitConversationFromSession(
+      this.app.components.IoHandler,
+      session,
+      result,
+      req.params.id,
+      "Session",
+    )
     model.sessionData.deleteByOrganizationAndSession(
       session.organizationId,
       req.params.id,
@@ -485,18 +529,21 @@ async function storeQuickMeetingFromStop(req, next) {
     if (req.query.trash === "true") {
       next()
     } else {
-      const session = await axios.get(
-        process.env.SESSION_API_ENDPOINT + `/sessions/${req.params.id}`,
+      const sessionCheck = await axios.get(
+        process.env.SESSION_API_ENDPOINT +
+          `/sessions/${req.params.id}?withCaptions=false`,
       )
-      if (session.owner === req.payload.data.userId) {
+      if (sessionCheck.owner === req.payload.data.userId) {
+        const session = await stopSessionAndFetch(req.params.id)
         let result = await storeSession(session, req.query.name)
 
-        if (this.app.components.IoHandler !== undefined) {
-          this.app.components.IoHandler.emit("new_conversation_from_session", {
-            organizationId: session.organizationId,
-            ...result,
-          })
-        }
+        emitConversationFromSession(
+          this.app.components.IoHandler,
+          session,
+          result,
+          req.params.id,
+          "Quick meeting",
+        )
         next()
       } else {
         throw new SessionError(

--- a/studio-api/lib/utility/axios.js
+++ b/studio-api/lib/utility/axios.js
@@ -62,12 +62,12 @@ class Axios {
     return result
   }
 
-  async put(host, form) {
+  async put(host, form, config = {}) {
     let options = {
       ...form,
     }
     try {
-      const resp = await axios.put(host, options)
+      const resp = await axios.put(host, options, config)
       return resp.data
     } catch (error) {
       throw error


### PR DESCRIPTION
## What

On session / quick-meeting stop, studio-api now stops the session through the **drain barrier** before reading it for conversion:

```
PUT /sessions/:id/stop?force=true&waitFinal=true   (then) GET /sessions/:id
```

The Session API only returns once every channel has been deactivated by its transcriber and all finals are committed, so the conversion sees the **complete** transcript.

## Why

This fixes the known race where the **last Azure final** is flushed when the stream closes and the session→conversation conversion reads the captions *before* it lands in Postgres — the conversion then silently stores nothing (HTTP 200, empty media). It is the proper backend fix behind `4e8bcf70` (which had worked around the symptom by switching the stop button to the delete endpoint).

## Changes

- `conversation.js`: `stopSessionAndFetch()` — PUT stop(`waitFinal=true`) before the GET; owner check for quick meetings now uses a lightweight `?withCaptions=false` GET *before* stopping; warns when a stop produced no storable captions.
- `axios.js`: `put()` accepts a per-request config (used for the stop timeout).
- `.envdefault`: `SESSION_STOP_TIMEOUT_MS=15000` (kept above the Session API flush timeout).

## Compatibility & dependency

- Degrades gracefully: older Session APIs that ignore `waitFinal` return immediately → previous read-once behaviour, never worse.
- **Depends on the server-side drain barrier** already merged into `linto-studio-plugins@next`:
  - [`9c21d46`](https://github.com/linto-ai/linto-studio-plugins/commit/9c21d46d8740ee1eb3842353da0f22d701ea061a) — [Transcriber] Flush in-flight ASR finals before the end-of-stream marker on stop
  - [`e5ee0ef`](https://github.com/linto-ai/linto-studio-plugins/commit/e5ee0ef98125a2912dc94ec4d7a3a0c442890ca3) — [Scheduler] Serialize per-channel persistence to match MQTT commit order
  - [`6893ac4`](https://github.com/linto-ai/linto-studio-plugins/commit/6893ac4af691fa3743e335bf75342066b894b815) — [Session-API] Add stop?waitFinal drain barrier until channels deactivate

## Validation

End-to-end Microsoft ASR scenario (mic → live FR/EN captions → stop → media) passes on both the Session and Quick-Meeting paths (the latter being exactly the failing case), 100% caption overlap.
