### PR TITLE
[studio-api] Log channel unmount when a session vanishes from the statuses broadcast

### DIFF
--- a/studio-api/components/BrokerClient/controllers/MqttActivityLog.js
+++ b/studio-api/components/BrokerClient/controllers/MqttActivityLog.js
@@ -44,6 +44,10 @@ module.exports = function () {
     await redis.hSet(REDIS_HASH_KEY, Object.fromEntries(updates))
   }
 
+  // A terminated session vanishes from the broadcast, so its unmount is never
+  // broadcast; recover it by diffing each broadcast against the previous one.
+  let previousActive = new Map()
+
   this.sharedClient.on("message", async (topic, message) => {
     if (topic !== "system/out/sessions/statuses") return
 
@@ -58,17 +62,30 @@ module.exports = function () {
     if (!Array.isArray(sessions)) return
 
     const entries = []
+    const presentKeys = new Set()
+    const currentActive = new Map()
     for (const session of sessions) {
       for (const channel of session.channels || []) {
-        entries.push({ key: `${session.id}:${channel.id}`, session, channel })
+        const key = `${session.id}:${channel.id}`
+        const entry = { key, session, channel }
+        entries.push(entry)
+        presentKeys.add(key)
+        if (channel.streamStatus === "active") currentActive.set(key, entry)
       }
+    }
+
+    // Scoped to previousActive so we never retro-close stale historical mounts.
+    const vanished = []
+    for (const [key, entry] of previousActive) {
+      if (!presentKeys.has(key)) vanished.push(entry)
     }
 
     let stateMap
     try {
-      stateMap = await readAllChannelStates(entries)
+      stateMap = await readAllChannelStates([...entries, ...vanished])
     } catch (err) {
       logger.error(`activityLog: failed to read channel states: ${err}`)
+      previousActive = currentActive
       return
     }
 
@@ -95,10 +112,23 @@ module.exports = function () {
       }
     }
 
+    // Gate on persisted state so concurrent instances don't double-log.
+    for (const { key, session, channel } of vanished) {
+      if ((stateMap.get(key) ?? "inactive") !== "active") continue
+      writes.set(key, "inactive")
+      LogManager.logChannelEvent(session, channel, "unmount").catch((err) =>
+        logger.error(
+          `activityLog: logChannelEvent unmount (vanished) failed: ${err}`,
+        ),
+      )
+    }
+
     try {
       await writeAllChannelStates(writes)
     } catch (err) {
       logger.error(`activityLog: failed to persist channel states: ${err}`)
     }
+
+    previousActive = currentActive
   })
 }

--- a/studio-api/tests/test/activity/mqttActivityLog.test.js
+++ b/studio-api/tests/test/activity/mqttActivityLog.test.js
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for the MqttActivityLog controller: mount/unmount events derived
+ * from the sessions/statuses broadcast, including the "vanished" channel case.
+ * Redis is left unconfigured so the Mongo fallback (getLastChannelEvent) is used.
+ */
+const EventEmitter = require("events")
+
+const mockGetLastChannelEvent = jest.fn()
+jest.mock(`${process.cwd()}/lib/mongodb/models`, () => ({
+  activityLog: {
+    getLastChannelEvent: (...a) => mockGetLastChannelEvent(...a),
+    create: jest.fn(),
+  },
+}))
+
+const mockLogChannelEvent = jest.fn()
+jest.mock(`${process.cwd()}/lib/logger/manager`, () => ({
+  logChannelEvent: (...a) => mockLogChannelEvent(...a),
+}))
+
+jest.mock(`${process.cwd()}/lib/logger/logger`, () => ({
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+  log() {},
+}))
+
+const MqttActivityLog = require(
+  `${process.cwd()}/components/BrokerClient/controllers/MqttActivityLog`,
+)
+
+const TOPIC = "system/out/sessions/statuses"
+// The handler is async (awaits state reads); drain several microtask/macrotask
+// turns so all of its awaited work settles before we assert.
+const flush = async () => {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setImmediate(r))
+}
+
+function setup() {
+  const sharedClient = new EventEmitter()
+  const ctx = {
+    sharedClient,
+    app: { components: { IoHandler: { redisPubClient: null } } },
+  }
+  MqttActivityLog.call(ctx)
+  return sharedClient
+}
+
+function broadcast(client, sessions) {
+  // The MQTT client emits a "message" event carrying (topic, payload).
+  client.emit("message", TOPIC, Buffer.from(JSON.stringify(sessions)))
+  return flush()
+}
+
+const activeSession = {
+  id: "sess-1",
+  name: "S1",
+  organizationId: "org-1",
+  visibility: "private",
+  status: "active",
+  channels: [{ id: 42, streamStatus: "active", translations: [] }],
+}
+
+const actionsLogged = () => mockLogChannelEvent.mock.calls.map((c) => c[2])
+
+beforeEach(() => {
+  mockGetLastChannelEvent.mockReset()
+  mockLogChannelEvent.mockReset().mockResolvedValue(undefined)
+})
+
+describe("MqttActivityLog channel events", () => {
+  it("logs a mount when a channel first appears active", async () => {
+    mockGetLastChannelEvent.mockResolvedValue(null) // no prior event
+    const client = setup()
+
+    await broadcast(client, [activeSession])
+
+    expect(actionsLogged()).toEqual(["mount"])
+    expect(mockLogChannelEvent.mock.calls[0][1].id).toBe(42)
+  })
+
+  it("logs an unmount when an active channel VANISHES from the broadcast", async () => {
+    mockGetLastChannelEvent
+      .mockResolvedValueOnce(null) // broadcast 1: mount check, no prior
+      .mockResolvedValue({ action: "mount" }) // broadcast 2: vanished gate -> still active
+    const client = setup()
+
+    await broadcast(client, [activeSession]) // active
+    await broadcast(client, []) // session terminated -> gone from broadcast
+
+    expect(actionsLogged()).toEqual(["mount", "unmount"])
+    // the unmount carries the context captured while the channel was active
+    const unmount = mockLogChannelEvent.mock.calls.find(
+      (c) => c[2] === "unmount",
+    )
+    expect(unmount[0].id).toBe("sess-1")
+    expect(unmount[1].id).toBe(42)
+    // regression: the state lookup must use the NUMERIC channel id, else the
+    // Mongo type-strict match misses and the vanished gate never fires.
+    expect(mockGetLastChannelEvent).toHaveBeenCalledWith("sess-1", 42)
+    expect(mockGetLastChannelEvent).not.toHaveBeenCalledWith("sess-1", "42")
+  })
+
+  it("logs an unmount when a present channel flips to inactive", async () => {
+    mockGetLastChannelEvent
+      .mockResolvedValueOnce(null) // b1 mount
+      .mockResolvedValue({ action: "mount" }) // b2 present-inactive gate -> active
+    const client = setup()
+
+    await broadcast(client, [activeSession])
+    await broadcast(client, [
+      {
+        ...activeSession,
+        status: "ready",
+        channels: [{ id: 42, streamStatus: "inactive", translations: [] }],
+      },
+    ])
+
+    expect(actionsLogged()).toEqual(["mount", "unmount"])
+  })
+
+  it("does not double-unmount a channel once it has vanished", async () => {
+    mockGetLastChannelEvent
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ action: "mount" })
+    const client = setup()
+
+    await broadcast(client, [activeSession])
+    await broadcast(client, []) // vanish -> unmount
+    await broadcast(client, []) // still gone -> nothing
+
+    expect(actionsLogged().filter((a) => a === "unmount")).toHaveLength(1)
+  })
+
+  it("keeps a still-active channel mounted without duplicate events", async () => {
+    mockGetLastChannelEvent
+      .mockResolvedValueOnce(null) // b1 mount
+      .mockResolvedValue({ action: "mount" }) // b2 still active
+    const client = setup()
+
+    await broadcast(client, [activeSession])
+    await broadcast(client, [activeSession]) // unchanged
+
+    expect(actionsLogged()).toEqual(["mount"])
+  })
+
+  it("never retro-closes a stale historical mount it never observed active", async () => {
+    // Mongo may still think some channel is mounted, but if we never saw it
+    // active in a previous broadcast, the first (empty) broadcast must not
+    // emit a flood of bogus unmounts.
+    mockGetLastChannelEvent.mockResolvedValue({ action: "mount" })
+    const client = setup()
+
+    await broadcast(client, []) // previousActive is empty
+
+    expect(mockLogChannelEvent).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What

`MqttActivityLog` derives channel `mount`/`unmount` activity from transitions in the retained `system/out/sessions/statuses` broadcast. The KPI streaming time (`getKpiSession.totalStreamingTime`) is computed from `mount`/`unmount` **pairs** — but unmounts were never logged, leaving every mount unpaired.

## Two bugs, both fixed here

1. **Vanished sessions.** A terminated/deleted session drops out of the statuses broadcast entirely (the Scheduler only broadcasts `active`/`ready`/`paused`), so its channels' `active->inactive` transition is never broadcast and the unmount was never observed. → Diff each broadcast against the previous one to emit the missing unmount, scoped to the previous broadcast so stale historical mounts are never retro-closed.

2. **`channelId` type mismatch (pre-existing).** The Mongo prev-state lookup queried `getLastChannelEvent` with a *stringified* channel id (split from the `sessionId:channelId` key) while it is stored as a **number** → the type-strict match never hit, so the unmount gate always skipped (this also broke the present→inactive unmount in the no-redis path). → Coerce the id back to a number.

## Verification

- **Unit:** Jest coverage incl. mount, vanished→unmount, present→inactive unmount, no double-unmount, still-active no-op, no retro-close of stale mounts, and a numeric-id regression assertion. Proven to fail pre-patch / pass post-patch.
- **End-to-end (live stack + Microsoft ASR scenario):** before the fix the `activityLog` had `mount` events and **0 `unmount`**; after, every stop logs **exactly one `mount` + one `unmount` per channel**, correctly paired, no duplicates.

Independent of the drain-barrier change (#333); the unmount KPI was already broken before it.