### PR TITLE
✨(sdk) split upload/poll_media + add get_media for idempotent resume

### DIFF
--- a/studio-sdk/python/linto/main.py
+++ b/studio-sdk/python/linto/main.py
@@ -11,9 +11,16 @@ class LinTO:
             base_url=base_url, token=auth_token
         )
 
-    async def transcribe(self, file, enable_diarization=True, number_of_speaker="0", language="*", enablePunctuation=True, name=f"imported file {datetime.now().isoformat()}", members_right=None):
-        args = {}
-        args["file"] = file
+    async def upload(self, file, enable_diarization=True, number_of_speaker="0", language="*", enablePunctuation=True, name=None, members_right=None):
+        """Upload a file and return its conversation_id, without polling.
+
+        Performs only the upload step. The returned conversation_id can be
+        checkpointed and later passed to poll_media() to resume waiting for
+        the transcription result without re-uploading (which would create a
+        duplicate conversation).
+        """
+        if name is None:
+            name = f"imported file {datetime.now().isoformat()}"
         res = await self.api_service.upload_file(
             file=file,
             enable_diarization=enable_diarization,
@@ -23,8 +30,41 @@ class LinTO:
             name=name,
             membersRight=members_right,
         )
-        media_id = res["conversationId"]
-        return PollingService(media_id, self.api_service)
+        return res["conversationId"]
+
+    async def get_media(self, conversation_id):
+        """One-shot fetch of a FINISHED media (no polling loop).
+
+        Use this on a resume path when the transcription is already known to be
+        done (e.g. a checkpointed step); use poll_media() when you still need to
+        wait for completion. Does NOT verify the job state — the caller must only
+        call it once completion is known. Raises on HTTP failure.
+        """
+        return await self.api_service.get_media(mediaId=conversation_id)
+
+    async def poll_media(self, conversation_id):
+        """Return a polling/resume handle for an already-created conversation.
+
+        Wraps an existing conversation_id (e.g. one returned by upload()) in a
+        PollingService that auto-starts polling and emits "done", "error" and
+        "update" events. Use this to resume after a crash/retry without
+        re-uploading the file.
+        """
+        return PollingService(conversation_id, self.api_service)
+
+    async def transcribe(self, file, enable_diarization=True, number_of_speaker="0", language="*", enablePunctuation=True, name=None, members_right=None):
+        if name is None:
+            name = f"imported file {datetime.now().isoformat()}"
+        conversation_id = await self.upload(
+            file=file,
+            enable_diarization=enable_diarization,
+            number_of_speaker=number_of_speaker,
+            language=language,
+            enablePunctuation=enablePunctuation,
+            name=name,
+            members_right=members_right,
+        )
+        return await self.poll_media(conversation_id)
 
     async def list_services(self):
         return await self.api_service.fetch_asr_services()

--- a/studio-sdk/python/linto/services/pollingService.py
+++ b/studio-sdk/python/linto/services/pollingService.py
@@ -63,3 +63,6 @@ class PollingService(EventEmitter):
         except asyncio.CancelledError:
             logging.debug("job cancelled")
             pass
+        except Exception as exc:  # noqa: BLE001 - surface the failure to the awaiter
+            await self.emit("exception", exc)
+            self.stop()

--- a/studio-sdk/python/tests/test_resume.py
+++ b/studio-sdk/python/tests/test_resume.py
@@ -1,0 +1,226 @@
+"""Tests for the idempotent upload / resume API.
+
+Covers the split introduced for crash-safe resume:
+  - upload()      -> returns conversation_id only (no polling)
+  - get_media()   -> one-shot fetch of a finished media (resume path)
+  - poll_media()  -> wraps an existing conversation_id in a polling handle
+  - transcribe()  -> upload() + poll_media() composition (single upload)
+and the PollingService "exception" event that surfaces a polling failure
+to the awaiter instead of hanging forever.
+"""
+
+import asyncio
+import inspect
+
+import pytest
+
+from linto.main import LinTO
+from linto.services.studioApiService import StudioApiService
+from linto.services.pollingService import PollingService
+
+
+def _status(state):
+    return {"jobs": {"transcription": {"state": state}}}
+
+
+class FakeApiService:
+    """Minimal api_service stand-in for PollingService tests."""
+
+    def __init__(self, statuses=None, media=None, raise_on_status=None):
+        # `statuses` are returned successively by get_media_status; once
+        # exhausted the job stays "started" (in progress) forever.
+        self._statuses = list(statuses or [])
+        self._media = media if media is not None else {"transcription": "hello"}
+        self._raise_on_status = raise_on_status
+        self.get_media_calls = 0
+        self.last_media_id = None
+
+    async def get_media_status(self, mediaId=None):
+        self.last_media_id = mediaId
+        if self._raise_on_status is not None:
+            raise self._raise_on_status
+        if self._statuses:
+            return self._statuses.pop(0)
+        return _status("started")
+
+    async def get_media(self, mediaId=None):
+        self.get_media_calls += 1
+        self.last_media_id = mediaId
+        return self._media
+
+
+class TestUpload:
+    async def test_returns_conversation_id(self, monkeypatch):
+        async def fake_upload(self_, **kwargs):
+            return {"conversationId": "conv-xyz"}
+
+        monkeypatch.setattr(StudioApiService, "upload_file", fake_upload)
+
+        client = LinTO(auth_token="dummy", base_url="http://test")
+        cid = await client.upload(file=b"audio", language="fr")
+        assert cid == "conv-xyz"
+
+    async def test_maps_kwargs_to_api_service(self, monkeypatch):
+        captured = {}
+
+        async def fake_upload(self_, **kwargs):
+            captured.update(kwargs)
+            return {"conversationId": "c"}
+
+        monkeypatch.setattr(StudioApiService, "upload_file", fake_upload)
+
+        client = LinTO(auth_token="dummy", base_url="http://test")
+        await client.upload(
+            file=b"audio",
+            language="fr",
+            enable_diarization=False,
+            number_of_speaker="2",
+            enablePunctuation=False,
+            members_right=3,
+        )
+        # language -> lang (so the upload_file decorator sees it)
+        assert captured["lang"] == "fr"
+        assert "language" not in captured
+        # members_right -> membersRight
+        assert captured["membersRight"] == 3
+        assert captured["enable_diarization"] is False
+        assert captured["number_of_speaker"] == "2"
+        assert captured["enablePunctuation"] is False
+
+    async def test_default_name_is_generated_at_call_time(self, monkeypatch):
+        names = []
+
+        async def fake_upload(self_, **kwargs):
+            names.append(kwargs["name"])
+            return {"conversationId": "c"}
+
+        monkeypatch.setattr(StudioApiService, "upload_file", fake_upload)
+
+        client = LinTO(auth_token="dummy", base_url="http://test")
+        await client.upload(file=b"a")
+        assert names[0].startswith("imported file ")
+
+    def test_name_default_is_none_not_a_frozen_timestamp(self):
+        # Regression: the default must be None (computed in the body), never a
+        # f-string evaluated once at import time — which would stamp every
+        # upload with the SAME timestamp for the whole process lifetime.
+        assert inspect.signature(LinTO.upload).parameters["name"].default is None
+
+    async def test_explicit_name_passed_through(self, monkeypatch):
+        captured = {}
+
+        async def fake_upload(self_, **kwargs):
+            captured.update(kwargs)
+            return {"conversationId": "c"}
+
+        monkeypatch.setattr(StudioApiService, "upload_file", fake_upload)
+
+        client = LinTO(auth_token="dummy", base_url="http://test")
+        await client.upload(file=b"a", name="my media")
+        assert captured["name"] == "my media"
+
+
+class TestGetMedia:
+    async def test_delegates_one_shot_with_media_id(self, monkeypatch):
+        captured = {}
+
+        async def fake_get_media(self_, mediaId=None):
+            captured["mediaId"] = mediaId
+            return {"transcription": "final"}
+
+        monkeypatch.setattr(StudioApiService, "get_media", fake_get_media)
+
+        client = LinTO(auth_token="dummy", base_url="http://test")
+        res = await client.get_media("conv-1")
+        assert captured["mediaId"] == "conv-1"
+        assert res == {"transcription": "final"}
+
+
+class TestPollMedia:
+    async def test_wraps_existing_conversation(self):
+        fake = FakeApiService()
+        client = LinTO(auth_token="dummy", base_url="http://test")
+        client.api_service = fake
+
+        handle = await client.poll_media("conv-1")
+        try:
+            assert isinstance(handle, PollingService)
+            assert handle.media_id == "conv-1"
+            assert handle.api_service is fake
+        finally:
+            handle.stop()
+
+
+class TestTranscribeComposition:
+    async def test_uploads_once_then_polls_that_conversation(self, monkeypatch):
+        upload_calls = []
+
+        async def fake_upload(self_, **kwargs):
+            upload_calls.append(kwargs)
+            return {"conversationId": "conv-42"}
+
+        monkeypatch.setattr(StudioApiService, "upload_file", fake_upload)
+
+        client = LinTO(auth_token="dummy", base_url="http://test")
+        handle = await client.transcribe(file=b"audio", language="fr")
+        try:
+            assert len(upload_calls) == 1  # no duplicate upload
+            assert isinstance(handle, PollingService)
+            assert handle.media_id == "conv-42"  # polls the uploaded conversation
+        finally:
+            handle.stop()
+
+
+class TestPollingServiceEvents:
+    async def test_emits_exception_event_and_stops_on_status_failure(self):
+        boom = RuntimeError("studio down")
+        fake = FakeApiService(raise_on_status=boom)
+        handle = PollingService("conv-1", fake, interval=0.01)
+
+        captured = {}
+        done = asyncio.Event()
+
+        async def on_exc(exc):
+            captured["exc"] = exc
+            done.set()
+
+        handle.on("exception", on_exc)
+        await asyncio.wait_for(done.wait(), timeout=2)
+
+        assert captured["exc"] is boom  # the real cause is surfaced
+        assert handle._task is None  # the loop stopped itself
+
+    async def test_emits_done_with_fetched_media(self):
+        fake = FakeApiService(
+            statuses=[_status("started"), _status("done")],
+            media={"transcription": "final text"},
+        )
+        handle = PollingService("conv-1", fake, interval=0.01)
+
+        result = {}
+        done = asyncio.Event()
+
+        async def on_done(media):
+            result["media"] = media
+            done.set()
+
+        handle.on("done", on_done)
+        await asyncio.wait_for(done.wait(), timeout=2)
+
+        assert result["media"] == {"transcription": "final text"}
+        assert fake.get_media_calls == 1  # full media fetched exactly once
+        assert handle._task is None
+
+    async def test_emits_error_event_and_stops(self):
+        fake = FakeApiService(statuses=[_status("error")])
+        handle = PollingService("conv-1", fake, interval=0.01)
+
+        done = asyncio.Event()
+
+        async def on_error():
+            done.set()
+
+        handle.on("error", on_error)
+        await asyncio.wait_for(done.wait(), timeout=2)
+
+        assert handle._task is None


### PR DESCRIPTION
## Why

The Python SDK's `transcribe()` bundles the file **upload** — which creates a Studio conversation (a non-idempotent side effect) — with the **wait/poll** for the result. A caller that retries the whole flow after a crash re-uploads and creates a **duplicate conversation**.

This is needed by the Meet/Visio recording pipeline, which now retries failed transcriptions with exponential back-off and must resume **without** duplicating the conversation.

## What

Expose the seam so upload and wait are independently callable (backward compatible):

- `upload(file, ...) -> conversation_id` — upload only, no polling.
- `poll_media(conversation_id)` — resume polling an already-created conversation.
- `get_media(conversation_id)` — one-shot fetch of a finished media (no poll loop), for the resume path.
- `transcribe()` now composes `upload()` + `poll_media()` → **same behaviour and signature** as before.

A caller checkpoints the `conversation_id` returned by `upload()` and, on retry, resumes via `poll_media()`/`get_media()` without re-uploading.

Also:
- `PollingService._poll_loop` now surfaces poll failures as a first-class `"exception"` event (it previously caught only `CancelledError`, so an HTTP 5xx during polling escaped the background task and hung the awaiter instead of failing fast).
- Fix the evaluated-once `name=` default (was bound at import time).

## Scope

Only `studio-sdk/python/linto/` (the Python SDK). No version bump here — bump + publish to PyPI as a follow-up.