### PR TITLE
feat(publication): scope export templates per service

### DIFF
--- a/studio-api/components/WebServer/controllers/services/utility.js
+++ b/studio-api/components/WebServer/controllers/services/utility.js
@@ -74,17 +74,28 @@ async function getTranscriptionServiceByEndpoint(endpoint) {
  *   If not provided, returns all services
  * @param {string} [securityLevel] - Optional security level to filter flavors
  *   Flavors are filtered by model.security_level, services with no remaining flavors are removed
+ * @param {string} [userId] - Optional user ID; also returns services whose allowed
+ *   user list includes this user (in addition to global + org services)
  */
-async function listLlmServices(organizationId = null, securityLevel = null) {
+async function listLlmServices(
+  organizationId = null,
+  securityLevel = null,
+  userId = null,
+) {
   try {
     const gateway_services = process.env.LLM_GATEWAY_SERVICES
     debug("Security level requested:", securityLevel)
     // V2 API endpoint with pagination
     let host = gateway_services + "/api/v1/services?page=1&page_size=100"
 
-    // Add organization filter if provided
+    // Add organization filter if provided. The gateway returns global services
+    // plus those whose allowed org/user lists include the caller.
     if (organizationId) {
       host += `&organization_id=${encodeURIComponent(organizationId)}`
+    }
+    // Add user filter so services scoped to this specific user are also returned
+    if (userId) {
+      host += `&user_id=${encodeURIComponent(userId)}`
     }
 
     // Add timeout to prevent hanging if LLM Gateway is unresponsive

--- a/studio-api/components/WebServer/routecontrollers/publication/publication.js
+++ b/studio-api/components/WebServer/routecontrollers/publication/publication.js
@@ -39,22 +39,40 @@ async function getTemplates(req, res, next) {
     // Get authenticated user's ID from JWT payload
     const authenticatedUserId = req.payload?.data?.userId
 
-    // Build query params for hierarchical visibility
-    const params = new URLSearchParams()
-    params.append("include_system", "true")
+    // When a service_id is provided, return only the templates the admin made
+    // available for that service (falls back to the global default if none are
+    // linked). Otherwise return all templates visible to the org/user.
+    let url
+    if (req.query.service_id) {
+      const params = new URLSearchParams()
+      if (req.query.organization_id) {
+        params.append("organization_id", req.query.organization_id)
+      }
+      if (authenticatedUserId) {
+        params.append("user_id", authenticatedUserId)
+      }
+      url = `${baseUrl}/api/v1/services/${encodeURIComponent(
+        req.query.service_id,
+      )}/templates?${params.toString()}`
+    } else {
+      // Build query params for hierarchical visibility
+      const params = new URLSearchParams()
+      params.append("include_system", "true")
 
-    // Add organization_id if provided (to get org-scoped templates)
-    if (req.query.organization_id) {
-      params.append("organization_id", req.query.organization_id)
+      // Add organization_id if provided (to get org-scoped templates)
+      if (req.query.organization_id) {
+        params.append("organization_id", req.query.organization_id)
+      }
+
+      // Add user_id for authenticated user (to get user-scoped templates)
+      if (authenticatedUserId) {
+        params.append("user_id", authenticatedUserId)
+      }
+
+      // CORRECT endpoint: /api/v1/document-templates (NOT /api/v1/templates)
+      url = `${baseUrl}/api/v1/document-templates?${params.toString()}`
     }
 
-    // Add user_id for authenticated user (to get user-scoped templates)
-    if (authenticatedUserId) {
-      params.append("user_id", authenticatedUserId)
-    }
-
-    // CORRECT endpoint: /api/v1/document-templates (NOT /api/v1/templates)
-    const url = `${baseUrl}/api/v1/document-templates?${params.toString()}`
     const response = await axios.get(url, { timeout: 5000 })
 
     // Return with status wrapper, preserve all fields from LLM Gateway (including name_fr, name_en, etc.)

--- a/studio-api/components/WebServer/routecontrollers/services/service.js
+++ b/studio-api/components/WebServer/routecontrollers/services/service.js
@@ -39,9 +39,12 @@ async function getLlmServices(req, res, next) {
     // Pass organizationId and securityLevel from query params if provided
     const organizationId = req.params.organizationId || null
     const securityLevel = req.query.securityLevel || null
+    // Authenticated user, so user-scoped services are also returned
+    const userId = req.payload?.data?.userId || null
     const services = await serviceUtility.listLlmServices(
       organizationId,
       securityLevel,
+      userId,
     )
     res.status(200).send(services)
   } catch (err) {

--- a/studio-frontend/src/api/publication.js
+++ b/studio-frontend/src/api/publication.js
@@ -9,6 +9,8 @@ const CLIENT_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone
  * @param {Object} options - Optional filters
  * @param {string} [options.category] - Filter by category (e.g., "summary", "report")
  * @param {string} [options.organizationId] - Filter by organization ID
+ * @param {string} [options.serviceId] - Restrict to templates available for this service
+ *   (falls back to the global default template when the service has none linked)
  * @returns {Promise<Array>} List of templates
  */
 export async function apiGetPublicationTemplates(options = {}) {
@@ -18,6 +20,9 @@ export async function apiGetPublicationTemplates(options = {}) {
   }
   if (options.organizationId) {
     params.organization_id = options.organizationId
+  }
+  if (options.serviceId) {
+    params.service_id = options.serviceId
   }
 
   const req = await sendRequest(

--- a/studio-frontend/src/components/PublicationSection.vue
+++ b/studio-frontend/src/components/PublicationSection.vue
@@ -263,6 +263,11 @@ export default {
       required: false,
       default: null,
     },
+    serviceId: {
+      type: String,
+      required: false,
+      default: null,
+    },
     conversationName: {
       type: String,
       required: false,
@@ -345,6 +350,12 @@ export default {
         this.loadTemplates()
       },
     },
+    serviceId: {
+      immediate: false,
+      handler() {
+        this.loadTemplates()
+      },
+    },
   },
   mounted() {
     this.loadTemplates()
@@ -363,6 +374,7 @@ export default {
       try {
         this.templates = await apiGetPublicationTemplates({
           organizationId: this.organizationId,
+          serviceId: this.serviceId,
         })
       } catch (err) {
         this.error = this.$t("publish.publication.load_error")

--- a/studio-frontend/src/views/ConversationsPublish.vue
+++ b/studio-frontend/src/views/ConversationsPublish.vue
@@ -206,6 +206,7 @@
         <PublicationSection
           :jobId="currentJobId"
           :organizationId="publicationOrganizationId"
+          :serviceId="currentServiceId"
           :conversationName="conversation?.name || 'export'"
           :versionNumber="currentVersionNumber"
           hideHeader
@@ -565,6 +566,12 @@ export default {
     currentJobId() {
       return this.currentJob?.jobId || null
     },
+    currentServiceId() {
+      // Service backing the active AI tab; used to scope the template list to
+      // the templates the admin made available for this service.
+      if (this.activeTab === "verbatim") return null
+      return this.indexedFormat[this.activeTab]?.id || null
+    },
     publicationOrganizationId() {
       return this.conversation?.organization?.organizationId || null
     },
@@ -841,6 +848,7 @@ export default {
           if (res[format] === undefined) {
             res[format] = {}
           }
+          res[format]["id"] = service.id
           res[format]["flavors"] = service.flavors
           res[format]["description"] = service.description
           res[format]["route"] = service.route


### PR DESCRIPTION
## Résumé
Câble Studio sur le nouveau scoping par service du LLM-Gateway : la liste des templates d'export n'affiche plus tous les templates, mais ceux que l'admin a rendus disponibles pour le service concerné (sinon le template par défaut global).

## Changements
- **studio-api** `publication.js` `getTemplates` : accepte `service_id` et interroge `GET /api/v1/services/{id}/templates` du gateway (sinon comportement inchangé).
- **studio-api** `services/utility.js` + `service.js` : `listLlmServices` transmet aussi `user_id` → les services scopés utilisateur remontent.
- **studio-frontend** : `apiGetPublicationTemplates({ serviceId })` ; `PublicationSection.vue` reçoit `serviceId` ; `ConversationsPublish.vue` le fournit depuis l'onglet service actif.

## Compat
`createTemplate`/`deleteTemplate` inchangés (le gateway garde `scope`/`user_id` dérivés). Nécessite le gateway avec le multi-scope (PR llm-gateway#25).

## Vérifs
jest studio-api : 396 tests OK (dont `publication.test.js`) ; `node --check` OK.