### PR TITLE
feat(frontend): Teams & Visio meeting-bot in the session bot selector

### DIFF
--- a/studio-frontend/src/components/VisioCreateContent.vue
+++ b/studio-frontend/src/components/VisioCreateContent.vue
@@ -19,7 +19,7 @@
         :field="visioLinkField"
         v-model="visioLinkField.value"
         class="fullwidth"
-        placeholder="Jitsi link"
+        :placeholder="visioPlaceholder"
         required />
     </section>
 
@@ -102,7 +102,8 @@ export default {
         value: "",
         customParams: { placeholder: "https://meet.jit.si/..." },
         label: this.$i18n.t("quick_session.setup_visio.link_label"),
-        testField: testVisioUrl,
+        // Provider-aware URL validation; rewired by the visioTypeField watcher.
+        testField: (field, t) => testVisioUrl(field, t, "jitsi"),
       },
       quickSessionSettingsField: {
         ...EMPTY_FIELD,
@@ -121,7 +122,7 @@ export default {
         },
         testField: testQuickSessionSettings,
       },
-      supportedVisioServices: ["jitsi", "bigbluebutton"],
+      supportedVisioServices: ["jitsi", "bigbluebutton", "teams", "visio"],
       securityLevel: DEFAULT_SECURITY_LEVEL,
       formSubmitLabel: this.$t("quick_session.setup_visio.join_meeting"),
       formError: null,
@@ -132,6 +133,24 @@ export default {
   computed: {
     enableSecurityLevel() {
       return getEnv("VUE_APP_ENABLE_SECURITY_LEVEL") === "true"
+    },
+    visioPlaceholder() {
+      return (
+        {
+          jitsi: "https://meet.jit.si/...",
+          bigbluebutton: "https://bbb.example.com/...",
+          teams: "https://teams.microsoft.com/l/meetup-join/...",
+          visio: "https://visio.example.com/...",
+        }[this.visioTypeField.value] || ""
+      )
+    },
+  },
+  watch: {
+    // Re-point the link field's placeholder and validation at the selected provider.
+    "visioTypeField.value"(provider) {
+      this.visioLinkField.customParams = { placeholder: this.visioPlaceholder }
+      this.visioLinkField.testField = (field, t) =>
+        testVisioUrl(field, t, provider)
     },
   },
   methods: {

--- a/studio-frontend/src/tools/fields/testVisioUrl.js
+++ b/studio-frontend/src/tools/fields/testVisioUrl.js
@@ -1,7 +1,19 @@
 import { getEnv } from "../getEnv"
 
-export function testVisioUrl(field, t) {
-  const acceptedUrlsStrings = getEnv("VUE_APP_ACCEPTED_JITSI_URLS")
+// Per-provider URL allowlist env. An unset/empty allowlist accepts any URL
+// (the same permissive default the single-provider version had). Defaults to
+// jitsi for back-compat when no provider is passed.
+const ACCEPTED_URLS_ENV = {
+  jitsi: "VUE_APP_ACCEPTED_JITSI_URLS",
+  bigbluebutton: "VUE_APP_ACCEPTED_BBB_URLS",
+  teams: "VUE_APP_ACCEPTED_TEAMS_URLS",
+  visio: "VUE_APP_ACCEPTED_VISIO_URLS",
+}
+
+export function testVisioUrl(field, t, provider = "jitsi") {
+  const acceptedUrlsStrings = getEnv(
+    ACCEPTED_URLS_ENV[provider] || ACCEPTED_URLS_ENV.jitsi,
+  )
 
   let acceptedUrls = []
   if (acceptedUrlsStrings) {

--- a/studio-frontend/src/tools/fields/testVisioUrl.js
+++ b/studio-frontend/src/tools/fields/testVisioUrl.js
@@ -22,7 +22,10 @@ export function testVisioUrl(field, t, provider = "jitsi") {
 
   field.error = null
   field.valid = false
-  field.value = field.value.toLowerCase().trim()
+  // Only trim — DO NOT lowercase: meeting URLs carry case-sensitive tokens (e.g. a
+  // Teams join passcode `?p=T2pFGitIgRzJN2MKYl`), and lowercasing them breaks the
+  // bot's join. Host-allowlist matching below is done case-insensitively instead.
+  field.value = field.value.trim()
 
   if (field.value === "") {
     field.error = t("error.required")
@@ -34,7 +37,8 @@ export function testVisioUrl(field, t, provider = "jitsi") {
     return field.valid
   }
 
-  if (acceptedUrls.some((url) => field.value.includes(url))) {
+  const lowerValue = field.value.toLowerCase()
+  if (acceptedUrls.some((url) => lowerValue.includes(url.toLowerCase()))) {
     field.valid = true
     return field.valid
   }

--- a/studio-frontend/src/tools/fields/testVisioUrl.js
+++ b/studio-frontend/src/tools/fields/testVisioUrl.js
@@ -1,8 +1,6 @@
 import { getEnv } from "../getEnv"
 
-// Per-provider URL allowlist env. An unset/empty allowlist accepts any URL
-// (the same permissive default the single-provider version had). Defaults to
-// jitsi for back-compat when no provider is passed.
+// Per-provider URL allowlist env; an unset/empty allowlist accepts any URL.
 const ACCEPTED_URLS_ENV = {
   jitsi: "VUE_APP_ACCEPTED_JITSI_URLS",
   bigbluebutton: "VUE_APP_ACCEPTED_BBB_URLS",
@@ -22,9 +20,9 @@ export function testVisioUrl(field, t, provider = "jitsi") {
 
   field.error = null
   field.valid = false
-  // Only trim — DO NOT lowercase: meeting URLs carry case-sensitive tokens (e.g. a
-  // Teams join passcode `?p=T2pFGitIgRzJN2MKYl`), and lowercasing them breaks the
-  // bot's join. Host-allowlist matching below is done case-insensitively instead.
+  // Only trim, never lowercase: meeting URLs carry case-sensitive tokens (e.g. a
+  // Teams join passcode) that the bot needs intact. Allowlist matching below is
+  // done case-insensitively instead.
   field.value = field.value.trim()
 
   if (field.value === "") {


### PR DESCRIPTION
## What
Frontend support for launching a meeting bot on **Teams** and **Visio** from the session creation flow.

## Changes
- **feat(frontend):** offer Teams and Visio in the session bot selector (`VisioCreateContent.vue`).
- **fix:** don't lowercase the Visio/Teams join URL in validation — the previous `.toLowerCase()` corrupted the case-sensitive Teams meeting passcode (`?p=...`) so the bot was rejected. Now trims only, with a case-insensitive host allowlist match (`testVisioUrl.js`).
- **chore:** trim verbose comments in `testVisioUrl`.

## Notes
The backend bot orchestration (BotService / native diarization / Teams admission/leave) lives in `linto-studio-plugins` and is tracked separately.

Validated end-to-end: a bot launched from the Studio UI joins a Visio room and a Teams meeting, transcribes with 2 distinct speakers, stops from the UI, and leaves cleanly.