### PR TITLE
✨(sdk) support speaker identification in python SDK

### DIFF
--- a/studio-sdk/python/linto/main.py
+++ b/studio-sdk/python/linto/main.py
@@ -316,3 +316,32 @@ class LinTO:
             if collection.get("type") == "organization":
                 return str(collection.get("_id") or collection.get("id") or "") or None
         return None
+
+    async def get_voiceprint_collection(self, collection_id):
+        """Fetch a single voiceprint collection (group) by id."""
+        return await self.api_service.get_voiceprint_collection(
+            collectionId=collection_id
+        )
+
+    async def get_voiceprint_collection_id_by_name(self, name):
+        """Return the id of the voiceprint collection (group) named `name`, or None.
+
+        Case-insensitive match over list_voiceprint_collections(). Use this to
+        select a custom group by name for speaker identification, then pass the
+        id to upload(speaker_collection_ids=[...]).
+        """
+        collections = await self.list_voiceprint_collections()
+        if not isinstance(collections, list):
+            return None
+        for collection in collections:
+            if str(collection.get("name", "")).lower() == name.lower():
+                return str(collection.get("_id") or collection.get("id") or "") or None
+        return None
+
+    async def get_speaker_identification_status(self):
+        """Return the organization's speaker identification status.
+
+        Dict with enabled / reachable / modelId / dim / syncPending — handy to
+        check availability before requesting identification.
+        """
+        return await self.api_service.get_speaker_identification_status()

--- a/studio-sdk/python/linto/main.py
+++ b/studio-sdk/python/linto/main.py
@@ -11,13 +11,19 @@ class LinTO:
             base_url=base_url, token=auth_token
         )
 
-    async def upload(self, file, enable_diarization=True, number_of_speaker="0", language="*", enablePunctuation=True, name=None, members_right=None):
+    async def upload(self, file, enable_diarization=True, number_of_speaker="0", language="*", enablePunctuation=True, name=None, members_right=None, speaker_collection_ids=None):
         """Upload a file and return its conversation_id, without polling.
 
         Performs only the upload step. The returned conversation_id can be
         checkpointed and later passed to poll_media() to resume waiting for
         the transcription result without re-uploading (which would create a
         duplicate conversation).
+
+        Pass speaker_collection_ids (a list of voiceprint collection ids) to run
+        speaker identification during diarization; identified members' names
+        then populate speaker_name in the transcript. Use
+        get_org_voiceprint_collection_id() to obtain the organization-level
+        collection. Ignored unless diarization is effectively enabled.
         """
         if name is None:
             name = f"imported file {datetime.now().isoformat()}"
@@ -29,6 +35,7 @@ class LinTO:
             enablePunctuation=enablePunctuation,
             name=name,
             membersRight=members_right,
+            speakerIdentificationCollections=speaker_collection_ids,
         )
         return res["conversationId"]
 
@@ -52,7 +59,7 @@ class LinTO:
         """
         return PollingService(conversation_id, self.api_service)
 
-    async def transcribe(self, file, enable_diarization=True, number_of_speaker="0", language="*", enablePunctuation=True, name=None, members_right=None):
+    async def transcribe(self, file, enable_diarization=True, number_of_speaker="0", language="*", enablePunctuation=True, name=None, members_right=None, speaker_collection_ids=None):
         if name is None:
             name = f"imported file {datetime.now().isoformat()}"
         conversation_id = await self.upload(
@@ -63,6 +70,7 @@ class LinTO:
             enablePunctuation=enablePunctuation,
             name=name,
             members_right=members_right,
+            speaker_collection_ids=speaker_collection_ids,
         )
         return await self.poll_media(conversation_id)
 
@@ -280,3 +288,31 @@ class LinTO:
         return await self.api_service.move_conversation_to_folder(
             folderId=folder_id, conversationId=conversation_id
         )
+
+    # --- Speaker identification ---
+
+    async def list_voiceprint_collections(self):
+        """List the organization's voiceprint collections.
+
+        The org-level "Organization" collection (type "organization") is
+        auto-created and included by the backend on this call.
+        """
+        return await self.api_service.list_voiceprint_collections()
+
+    async def get_org_voiceprint_collection_id(self):
+        """Return the id of the organization's default voiceprint collection.
+
+        Speaker identification at organization scope targets a single collection
+        of type "organization" that holds every opted-in member's voiceprint —
+        no custom group selection. Returns its id, or None when the org has no
+        such collection. Raises on HTTP failure (e.g. the org lacks the
+        speaker-identification permission), so the caller can choose to
+        soft-fail.
+        """
+        collections = await self.list_voiceprint_collections()
+        if not isinstance(collections, list):
+            return None
+        for collection in collections:
+            if collection.get("type") == "organization":
+                return str(collection.get("_id") or collection.get("id") or "") or None
+        return None

--- a/studio-sdk/python/linto/services/studioApiService.py
+++ b/studio-sdk/python/linto/services/studioApiService.py
@@ -165,7 +165,35 @@ class StudioApiService:
         if kwargs.get("membersRight") is not None:
             form.add_field("membersRight", str(int(kwargs["membersRight"])))
 
+        # Speaker identification (org-level): forward the requested voiceprint
+        # collection ids so studio-api runs identification during diarization.
+        # Guarded on diarization being *effectively* enabled — with_upload_config
+        # downgrades enableDiarization to False when no diarization worker is
+        # available, and the backend rejects the whole upload when collections
+        # are sent without diarization.
+        collections = kwargs.get("speakerIdentificationCollections")
+        if collections and kwargs["transcriptionConfig"].get(
+            "diarizationConfig", {}
+        ).get("enableDiarization") is True:
+            form.add_field(
+                "speakerIdentificationCollections", json.dumps(list(collections))
+            )
+
         return await self._send_request("POST", url, data=form, token=kwargs["token"])
+
+    # --- Speaker identification methods ---
+
+    @with_token
+    @with_organization_id
+    async def list_voiceprint_collections(self, **kwargs):
+        """List the organization's voiceprint collections.
+
+        The backend auto-creates and includes the org-level "Organization"
+        collection (type == "organization") on this call.
+        """
+        org_id = kwargs["organizationId"]
+        url = f"{self.base_api_url}/organizations/{org_id}/voiceprint-collections"
+        return await self._send_request("GET", url, **kwargs)
 
     # --- LLM / Summary methods ---
 

--- a/studio-sdk/python/linto/services/studioApiService.py
+++ b/studio-sdk/python/linto/services/studioApiService.py
@@ -195,6 +195,28 @@ class StudioApiService:
         url = f"{self.base_api_url}/organizations/{org_id}/voiceprint-collections"
         return await self._send_request("GET", url, **kwargs)
 
+    @with_token
+    @with_organization_id
+    async def get_voiceprint_collection(self, collectionId, **kwargs):
+        """Fetch a single voiceprint collection (group) by id."""
+        org_id = kwargs["organizationId"]
+        url = (
+            f"{self.base_api_url}/organizations/{org_id}"
+            f"/voiceprint-collections/{collectionId}"
+        )
+        return await self._send_request("GET", url, **kwargs)
+
+    @with_token
+    @with_organization_id
+    async def get_speaker_identification_status(self, **kwargs):
+        """Get the organization's speaker identification status.
+
+        Returns enabled / reachable / modelId / dim / syncPending.
+        """
+        org_id = kwargs["organizationId"]
+        url = f"{self.base_api_url}/organizations/{org_id}/speaker-identification/status"
+        return await self._send_request("GET", url, **kwargs)
+
     # --- LLM / Summary methods ---
 
     @with_token

--- a/studio-sdk/python/pyproject.toml
+++ b/studio-sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linto"
-version = "1.3.0"
+version = "1.4.0"
 description = "Wrapper around LinTO Studio API"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
## What

Exposes LinTO Studio speaker identification through the Python SDK, so a caller can have speakers identified during diarization against one or more voiceprint collections.

### Collections ("groups")
- `list_voiceprint_collections()` — list all collections (the organization default **and** custom groups). The backend auto-creates and includes the org-level `type == "organization"` collection.
- `get_voiceprint_collection(id)` — fetch a single collection.
- `get_voiceprint_collection_id_by_name(name)` — resolve a group by name (case-insensitive).
- `get_org_voiceprint_collection_id()` — convenience helper for the organization-level default collection.

### Identification
- `speaker_collection_ids` on `upload()` / `transcribe()` — forwarded as the `speakerIdentificationCollections` multipart field on `conversations/create`. Accepts **any** collection ids (org default and/or custom groups). Only sent when diarization is effectively enabled (studio-api rejects an upload carrying collections without diarization).

### Status
- `get_speaker_identification_status()` — enabled / reachable / modelId / dim / syncPending.

Version bump 1.3.0 → 1.4.0.

## Validation
- SDK logic tests: org-collection resolution and the diarization guard (field omitted when no diarization worker / no collection).
- End-to-end against a local studio-api (`ENABLE_SPEAKER_IDENTIFICATION=true`): collection retrieval (list / get / by-name) and status work; `upload(speaker_collection_ids=[…])` is accepted and studio-api builds the expected `speakerIdentificationConfig` (Qdrant collection `spkid_{org}_{col}`).

The consumer-side integration lives in its own repo.
