### PR TITLE
feat(sdk-js): live meeting-bot flow (quickMeeting / sessions / bots)

### DIFF
--- a/studio-sdk/javascript/index.js
+++ b/studio-sdk/javascript/index.js
@@ -456,6 +456,204 @@ class LinTO {
     })
     return userId
   }
+
+  // ── Live meeting-bot flow (Visio/Meet) ────────────────────────────────────
+  // These drive a LIVE quick-meeting bot as the CURRENT USER, so a browser can
+  // own the whole flow (create the session, choose translations, launch/stop
+  // the bot) with the user's own Studio token — no server-side service account.
+
+  /**
+   * List the org's quickMeeting ASR profiles, normalized for a picker.
+   * @returns {Promise<Array<{id,name,languages:string[],translations:string[]}>>}
+   */
+  async listQuickMeetingProfiles({ organizationId } = {}) {
+    const profiles = await this.apiService.listTranscriberProfiles({
+      organizationId,
+      quickMeeting: true,
+    })
+    return (profiles || []).map((prof) => {
+      const config = prof.config || {}
+      const languages = (config.languages || [])
+        .map((l) => (typeof l === "object" ? l.candidate : l))
+        .filter(Boolean)
+      const rawTr =
+        prof.translations ||
+        config.availableTranslations ||
+        config.translations ||
+        []
+      const translations = Array.isArray(rawTr)
+        ? rawTr
+        : Object.values(rawTr)
+            .filter(Array.isArray)
+            .flat()
+      return {
+        id: getId(prof) || prof.id,
+        name: prof.name || config.name || "",
+        languages,
+        translations,
+      }
+    })
+  }
+
+  /**
+   * Create a quick-meeting session.
+   * @returns the raw session (with `id` and `channels`).
+   */
+  async createQuickMeeting({ organizationId, channels, meta } = {}) {
+    return await this.apiService.createQuickMeeting({
+      organizationId,
+      channels,
+      meta,
+    })
+  }
+
+  /** Patch a session's fields (e.g. `{ visibility }` or `{ meta }`). */
+  async patchSession({ organizationId, sessionId, data } = {}) {
+    return await this.apiService.patchSession({
+      organizationId,
+      sessionId,
+      data,
+    })
+  }
+
+  /** Launch a meeting bot on a channel (provider defaults to "visio"). */
+  async startBot({
+    organizationId,
+    url,
+    channelId,
+    provider = "visio",
+    enableDisplaySub = false,
+    subSource = "original",
+  } = {}) {
+    return await this.apiService.startBot({
+      organizationId,
+      url,
+      channelId,
+      provider,
+      enableDisplaySub,
+      subSource,
+    })
+  }
+
+  /** Stop a meeting bot by id. */
+  async stopBot({ organizationId, botId } = {}) {
+    return await this.apiService.stopBot({ organizationId, botId })
+  }
+
+  /** Stop (and finalize) a quick-meeting session; `name` names the resulting
+   * conversation so it can be resolved afterwards. */
+  async stopQuickMeeting({ organizationId, sessionId, name } = {}) {
+    return await this.apiService.stopQuickMeeting({
+      organizationId,
+      sessionId,
+      name,
+    })
+  }
+
+  /**
+   * Resolve the conversation finalized for a stopped quick session: match on
+   * `type.from_session_id === sessionId`, falling back to an exact `name`.
+   * @returns the conversation id, or null.
+   */
+  async findConversation({ organizationId, name, fromSessionId } = {}) {
+    const items = await this.apiService.listConversations({
+      organizationId,
+      name,
+    })
+    for (const item of items || []) {
+      const type = item.type || {}
+      if (type && type.from_session_id === fromSessionId) {
+        return getId(item) || item.id
+      }
+    }
+    for (const item of items || []) {
+      if (item.name === name) return getId(item) || item.id
+    }
+    return null
+  }
+
+  /**
+   * One-shot orchestration: create the quick-meeting, optionally patch its meta
+   * (e.g. inject a native bot join token), make it public, then launch the bot.
+   * Returns { sessionId, channelId, botId }.
+   *
+   * @param {Object} opts
+   * @param {string} [opts.organizationId]
+   * @param {Object} opts.channel - channel spec (name, transcriberProfileId,
+   *   enableLiveTranscripts, diarization, keepAudio, translations).
+   * @param {Object} [opts.meta] - session meta (native descriptor).
+   * @param {string} opts.botUrl - the room URL the bot navigates to.
+   * @param {string} [opts.provider="visio"]
+   * @param {boolean} [opts.makePublic=false] - PATCH visibility:"public".
+   * @param {(sessionId:string, channelId:string) => Promise<Object>} [opts.metaWithToken]
+   *   - async hook returning the FULL meta to persist once the channel id is
+   *   known (used to add a Meet-minted native join token before the bot starts).
+   */
+  async launchVisioBot({
+    organizationId,
+    channel,
+    meta,
+    botUrl,
+    provider = "visio",
+    makePublic = false,
+    metaWithToken,
+  } = {}) {
+    const session = await this.createQuickMeeting({
+      organizationId,
+      channels: [channel],
+      meta,
+    })
+    const sessionId = getId(session) || session.id
+    const channelId = ((session.channels || [])[0] || {}).id
+    if (!sessionId || !channelId) {
+      throw new Error(
+        `quickMeeting response missing ids: ${JSON.stringify(session)}`
+      )
+    }
+    // The org falls back to the first one inside the apiService; reuse the
+    // resolved value for the subsequent calls so they hit the same org.
+    const org =
+      organizationId || (this.apiService.organizations[0] || {})._id
+
+    if (makePublic) {
+      try {
+        await this.patchSession({
+          organizationId: org,
+          sessionId,
+          data: { visibility: "public" },
+        })
+      } catch (_) {
+        // Best-effort — only affects the public live token, not the bot.
+      }
+    }
+    if (typeof metaWithToken === "function") {
+      const fullMeta = await metaWithToken(sessionId, channelId)
+      if (fullMeta) {
+        await this.patchSession({
+          organizationId: org,
+          sessionId,
+          data: { meta: fullMeta },
+        })
+      }
+    }
+    let botId = null
+    try {
+      const bot = await this.startBot({
+        organizationId: org,
+        url: botUrl,
+        channelId,
+        provider,
+      })
+      botId = getId(bot) || bot.id
+    } catch (err) {
+      // Roll back the orphan session so Studio is not littered with a bot-less one.
+      try {
+        await this.stopQuickMeeting({ organizationId: org, sessionId })
+      } catch (_) {}
+      throw err
+    }
+    return { sessionId, channelId, botId, organizationId: org }
+  }
 }
 
 try {

--- a/studio-sdk/javascript/package.json
+++ b/studio-sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linto-ai/linto",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Wrapper around LinTO Studio API",
   "main": "index.js",
   "module": "index.js",

--- a/studio-sdk/javascript/src/services/studioApiService.js
+++ b/studio-sdk/javascript/src/services/studioApiService.js
@@ -201,6 +201,57 @@ export class StudioApiService {
     return res
   }
 
+  // -- Live session / quick-meeting / bot control --
+  //
+  // The methods below drive a LIVE meeting-bot flow (the Visio/Meet integration):
+  // list the org's quickMeeting ASR profiles, create/stop a quick-meeting
+  // session, patch its meta (e.g. inject a native bot join token), and
+  // start/stop a meeting bot. They are thin wrappers over the studio-api proxy
+  // routes `/api/organizations/{org}/...` and are authenticated as the CURRENT
+  // USER (the token passed to the SDK), so a browser can own the whole flow.
+
+  async listTranscriberProfiles(args = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#listTranscriberProfiles.bind(this))
+    )(args)
+  }
+
+  async createQuickMeeting(args = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#createQuickMeeting.bind(this))
+    )(args)
+  }
+
+  async stopQuickMeeting(args = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#stopQuickMeeting.bind(this))
+    )(args)
+  }
+
+  async patchSession(args = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#patchSession.bind(this))
+    )(args)
+  }
+
+  async startBot(args = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#startBot.bind(this))
+    )(args)
+  }
+
+  async stopBot(args = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#stopBot.bind(this))
+    )(args)
+  }
+
+  async listConversations(args = {}) {
+    return await this.#withToken(
+      this.#withOrganizationId(this.#listConversations.bind(this))
+    )(args)
+  }
+
   // -- Decorators --
 
   #withOrganizationId(method) {
@@ -295,6 +346,98 @@ export class StudioApiService {
     })
 
     return await sendRequest(req)
+  }
+
+  // -- Live session / quick-meeting / bot control (private API calls) --
+
+  async #listTranscriberProfiles({ token, organizationId, quickMeeting = true }) {
+    const query = buildQuery({ quickMeeting: quickMeeting ? "true" : undefined })
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/transcriber_profiles${query}`,
+      "GET",
+      { token }
+    )
+    const res = await sendRequest(req)
+    // The proxy may answer a bare list or an envelope — normalize to a list.
+    if (Array.isArray(res)) return res
+    return res?.transcriber_profiles || res?.list || []
+  }
+
+  async #createQuickMeeting({ token, organizationId, channels, meta }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/quickMeeting/`,
+      "POST",
+      { token, channels, ...(meta !== undefined ? { meta } : {}) }
+    )
+    return await sendRequest(req)
+  }
+
+  async #stopQuickMeeting({
+    token,
+    organizationId,
+    sessionId,
+    name,
+    force = true,
+    trash = false,
+  }) {
+    const query = buildQuery({
+      force: force ? "true" : undefined,
+      trash: trash ? "true" : undefined,
+      name,
+    })
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/quickMeeting/${sessionId}${query}`,
+      "DELETE",
+      { token }
+    )
+    return await sendRequest(req)
+  }
+
+  async #patchSession({ token, organizationId, sessionId, data }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/sessions/${sessionId}`,
+      "PATCH",
+      { token, ...(data || {}) }
+    )
+    return await sendRequest(req)
+  }
+
+  async #startBot({
+    token,
+    organizationId,
+    url,
+    channelId,
+    provider = "visio",
+    enableDisplaySub = false,
+    subSource = "original",
+  }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/bots`,
+      "POST",
+      { token, url, channelId, provider, enableDisplaySub, subSource }
+    )
+    return await sendRequest(req)
+  }
+
+  async #stopBot({ token, organizationId, botId }) {
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/bots/${botId}`,
+      "DELETE",
+      { token }
+    )
+    return await sendRequest(req)
+  }
+
+  async #listConversations({ token, organizationId, name }) {
+    const query = buildQuery({ name })
+    const req = prepareRequest(
+      `${this.baseApiUrl}/organizations/${organizationId}/conversations${query}`,
+      "GET",
+      { token }
+    )
+    const res = await sendRequest(req)
+    if (Array.isArray(res)) return res
+    return res?.conversations || res?.list || []
   }
 
   async #uploadFile({
@@ -629,4 +772,14 @@ export function generateServiceConfig(
 
 function removeLeadingSlash(str) {
   return str.replace(/^\/+/, "")
+}
+
+// Build a `?a=1&b=2` query string, skipping null/undefined/empty values.
+export function buildQuery(params) {
+  const usp = new URLSearchParams()
+  for (const [k, v] of Object.entries(params || {})) {
+    if (v !== undefined && v !== null && v !== "") usp.append(k, String(v))
+  }
+  const s = usp.toString()
+  return s ? `?${s}` : ""
 }

--- a/studio-sdk/javascript/test/liveSession.test.js
+++ b/studio-sdk/javascript/test/liveSession.test.js
@@ -1,0 +1,199 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the live meeting-bot flow added to the JS SDK (quickMeeting /
+ * sessions / bots / conversation resolution + the launchVisioBot orchestration).
+ * The network is mocked at the fetch layer.
+ */
+import { jest } from "@jest/globals"
+import LinTO from "../index.js"
+
+function makeFetchMock(handlers) {
+  const captured = []
+  const mock = jest.fn(async (req) => {
+    captured.push({
+      url: req.url,
+      method: req.method,
+      auth: req.headers.get("authorization"),
+      body: req.body ? await req.clone().text() : null,
+    })
+    for (const h of handlers) {
+      if (h.match(req)) {
+        const payload =
+          typeof h.payload === "function" ? await h.payload(req) : h.payload
+        return new Response(JSON.stringify(payload), {
+          status: h.status ?? 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+    }
+    return new Response(JSON.stringify({ error: "unmatched", url: req.url }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    })
+  })
+  return { mock, captured }
+}
+
+const ORG = "org-1"
+const BASE = "https://studio.test"
+
+describe("LinTO live meeting-bot flow", () => {
+  let linto
+  beforeEach(() => {
+    linto = new LinTO({ authToken: "tok-1", baseUrl: BASE })
+    // Pre-seed the org so #withOrganizationId does not fetch it.
+    linto.apiService.organizations = [{ _id: ORG }]
+  })
+  afterEach(() => jest.restoreAllMocks())
+
+  test("listQuickMeetingProfiles normalizes languages/translations", async () => {
+    const { mock } = makeFetchMock([
+      {
+        match: (r) =>
+          r.url.includes(`/organizations/${ORG}/transcriber_profiles`) &&
+          r.url.includes("quickMeeting=true"),
+        payload: [
+          {
+            id: "p-1",
+            config: {
+              name: "French",
+              languages: [{ candidate: "fr" }, "en"],
+              availableTranslations: { discrete: ["de"], external: ["es"] },
+            },
+          },
+        ],
+      },
+    ])
+    global.fetch = mock
+    const profiles = await linto.listQuickMeetingProfiles({ organizationId: ORG })
+    expect(profiles).toEqual([
+      { id: "p-1", name: "French", languages: ["fr", "en"], translations: ["de", "es"] },
+    ])
+  })
+
+  test("launchVisioBot creates the session, injects the token, and starts the bot", async () => {
+    const patches = []
+    const { mock, captured } = makeFetchMock([
+      {
+        match: (r) =>
+          r.method === "POST" && r.url.endsWith(`/organizations/${ORG}/quickMeeting/`),
+        payload: { id: "sess-1", channels: [{ id: "chan-1" }] },
+        status: 201,
+      },
+      {
+        match: (r) =>
+          r.method === "PATCH" && r.url.endsWith(`/organizations/${ORG}/sessions/sess-1`),
+        payload: async (r) => {
+          patches.push(JSON.parse(await r.clone().text()))
+          return {}
+        },
+      },
+      {
+        match: (r) => r.method === "POST" && r.url.endsWith(`/organizations/${ORG}/bots`),
+        payload: { id: "bot-1" },
+        status: 201,
+      },
+    ])
+    global.fetch = mock
+
+    const res = await linto.launchVisioBot({
+      organizationId: ORG,
+      channel: { name: "Main", transcriberProfileId: "p-1", enableLiveTranscripts: true },
+      meta: { native: { "visio-native": { livekitUrl: "ws://lk", room: "r1" } } },
+      botUrl: "https://meet.test/r1",
+      makePublic: true,
+      metaWithToken: async (sessionId, channelId) => {
+        expect(sessionId).toBe("sess-1")
+        expect(channelId).toBe("chan-1")
+        return {
+          native: { "visio-native": { livekitUrl: "ws://lk", room: "r1", token: "jwt" } },
+        }
+      },
+    })
+
+    expect(res).toEqual({
+      sessionId: "sess-1",
+      channelId: "chan-1",
+      botId: "bot-1",
+      organizationId: ORG,
+    })
+    // visibility public patch + meta-with-token patch both happened.
+    expect(patches).toContainEqual({ visibility: "public" })
+    expect(patches).toContainEqual({
+      meta: { native: { "visio-native": { livekitUrl: "ws://lk", room: "r1", token: "jwt" } } },
+    })
+    // The bot POST used the visio provider.
+    const botCall = captured.find((c) => c.url.endsWith("/bots"))
+    expect(JSON.parse(botCall.body).provider).toBe("visio")
+  })
+
+  test("launchVisioBot rolls back the session when the bot fails", async () => {
+    const deletes = []
+    const { mock } = makeFetchMock([
+      {
+        match: (r) => r.method === "POST" && r.url.endsWith(`/organizations/${ORG}/quickMeeting/`),
+        payload: { id: "sess-2", channels: [{ id: "chan-2" }] },
+        status: 201,
+      },
+      {
+        match: (r) => r.method === "POST" && r.url.endsWith(`/organizations/${ORG}/bots`),
+        payload: { error: "boom" },
+        status: 500,
+      },
+      {
+        match: (r) =>
+          r.method === "DELETE" && r.url.includes(`/organizations/${ORG}/quickMeeting/sess-2`),
+        payload: (r) => {
+          deletes.push(r.url)
+          return { success: true }
+        },
+      },
+    ])
+    global.fetch = mock
+    await expect(
+      linto.launchVisioBot({
+        organizationId: ORG,
+        channel: { name: "Main" },
+        botUrl: "https://meet.test/r2",
+      })
+    ).rejects.toThrow()
+    expect(deletes.length).toBe(1)
+  })
+
+  test("findConversation matches by from_session_id then by name", async () => {
+    const { mock } = makeFetchMock([
+      {
+        match: (r) => r.url.includes(`/organizations/${ORG}/conversations`),
+        payload: [
+          { _id: "c-other", name: "linto-x", type: { from_session_id: "zzz" } },
+          { _id: "c-match", name: "linto-x", type: { from_session_id: "sess-9" } },
+        ],
+      },
+    ])
+    global.fetch = mock
+    const id = await linto.findConversation({
+      organizationId: ORG,
+      name: "linto-x",
+      fromSessionId: "sess-9",
+    })
+    expect(id).toBe("c-match")
+  })
+
+  test("stopQuickMeeting passes force + name as query params (not a body)", async () => {
+    let seen
+    const { mock } = makeFetchMock([
+      {
+        match: (r) => r.method === "DELETE" && r.url.includes("/quickMeeting/sess-3"),
+        payload: (r) => {
+          seen = r.url
+          return { success: true }
+        },
+      },
+    ])
+    global.fetch = mock
+    await linto.stopQuickMeeting({ organizationId: ORG, sessionId: "sess-3", name: "linto-y" })
+    expect(seen).toContain("force=true")
+    expect(seen).toContain("name=linto-y")
+  })
+})


### PR DESCRIPTION
Add a browser-owned control surface to the JS SDK so a user (with their own Studio token) can drive a LIVE meeting bot end to end, instead of a server-side service account:
- listQuickMeetingProfiles, createQuickMeeting, patchSession, startBot, stopBot, stopQuickMeeting, findConversation (by type.from_session_id then name);
- launchVisioBot() orchestration: create quickMeeting -> optional make-public + meta-with-token hook (inject a Meet-minted native join token once the channel id is known) -> start bot, with session rollback on bot failure;
- StudioApiService gains the matching /api/organizations/{org}/... calls and a buildQuery helper (query params for DELETE/GET, never a body). Bumps the package to 1.3.0. 5 new tests; full suite 106 passing.